### PR TITLE
pytest/cfg-updates-and-cal-s3-predict-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ tests/data/svm/data/
 *.log
 *.backup
 .tmp
+tests/data

--- a/conftest.py
+++ b/conftest.py
@@ -109,7 +109,7 @@ class Config:
 
 
 def pytest_addoption(parser):
-    parser.addoption("--env", action="store", help="Environment to run tests against")
+    parser.addoption("--env", action="store", default="cal", help="Environment to run tests against")
 
 
 @fixture(scope="session")
@@ -270,5 +270,10 @@ def training_data_file(cfg):
     return cfg.labeled
 
 @fixture(scope="function")
-def cal_predict_visits(cfg, pipeline):
-    return cfg.visits[pipeline]
+def cal_predict_visits(cfg):
+    if cfg.env != "cal":
+        return {
+            "asn": ["j8zs05020", "ic0k06010", "la8mffg5q", "oc3p011i0"]
+        }
+    else:
+        return cfg.visits

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,8 @@ import os
 from pytest import fixture
 import tarfile
 from zipfile import ZipFile
+import boto3
+from moto import mock_s3
 from spacekit.analyzer.explore import HstCalPlots, HstSvmPlots
 from spacekit.analyzer.scan import SvmScanner, CalScanner, import_dataset
 from spacekit.extractor.load import load_datasets
@@ -95,6 +97,14 @@ class Config:
         self.tx_file = {
             "svm": "tests/data/svm/tx_data.json",
             "cal": "tests/data/cal/tx_data.json",
+        }[env]
+
+        self.visits = {
+            "svm": [],
+            "cal": {
+                "asn": ["j8zs05020", "ic0k06010", "la8mffg5q", "oc3p011i0"],
+                "svm": []
+            }
         }[env]
 
 
@@ -254,3 +264,11 @@ def scraped_mast_file():
 @fixture(scope="function")
 def cal_labeled_dataset():
     return "tests/data/cal/train/training.csv"
+
+@fixture(scope="function")
+def training_data_file(cfg):
+    return cfg.labeled
+
+@fixture(scope="function")
+def cal_predict_visits(cfg, pipeline):
+    return cfg.visits[pipeline]

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,8 @@ dev =
     pytest-profiling
     tox
     bandit
+    boto3
+    moto
 
 [options.package_data]
 spacekit = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,7 @@ install_requires =
     boto3
     matplotlib<4
     numpy>=1.19
-    # pandas 1.5 broke scrape_mast, encoder: "columns cannot be set"
-    pandas<1.5
+    pandas
     plotly
     progressbar
     stsci.tools

--- a/spacekit/analyzer/compute.py
+++ b/spacekit/analyzer/compute.py
@@ -19,7 +19,7 @@ from sklearn.metrics import (
 from tensorflow.python.ops.numpy_ops import np_config
 
 plt.style.use("seaborn-bright")
-font_dict = {"family": "monospace", "size": 16} # Titillium Web
+font_dict = {"family": "monospace", "size": 16}  # Titillium Web
 mpl.rc("font", **font_dict)
 
 

--- a/spacekit/analyzer/validate.py
+++ b/spacekit/analyzer/validate.py
@@ -169,7 +169,7 @@ for train_idx, test_idx in kfold.split(X, y):
     df.loc[test_idx_str, f"proba_{fold_no}"] = ptest
 
     p_aug = ens.model.predict(aug)
-    aug_pred = pd.DataFrame(p_aug, index=list(range(len(p_aug))), columns={nfold})
+    aug_pred = pd.DataFrame(p_aug, index=list(range(len(p_aug))), columns=[nfold])
     if len(df_aug) == 0:
         df_aug = aug_pred
     else:

--- a/spacekit/builder/architect.py
+++ b/spacekit/builder/architect.py
@@ -118,6 +118,8 @@ class Builder:
         archive_file = f"{arch}.zip" # calmodels.zip | ensemble.zip
         with importlib.resources.path(model_src, archive_file) as mod:
             self.model_path = mod
+        if arch == "calmodels" and self.blueprint is None:
+            self.blueprint = self.name
 
 
     def unzip_model_files(self, extract_to="models"):

--- a/spacekit/builder/architect.py
+++ b/spacekit/builder/architect.py
@@ -35,7 +35,14 @@ class Builder:
     """Class for building and training a neural network."""
 
     def __init__(
-        self, train_data=None, test_data=None, blueprint=None, model_path=None, name=None, logname="Builder", **log_kws
+        self,
+        train_data=None,
+        test_data=None,
+        blueprint=None,
+        model_path=None,
+        name=None,
+        logname="Builder",
+        **log_kws,
     ):
         if train_data is not None:
             self.X_train = train_data[0]
@@ -66,7 +73,6 @@ class Builder:
         self.__name__ = logname
         self.log = Logger(self.__name__, **log_kws).spacekit_logger()
 
-
     def load_saved_model(
         self, arch=None, compile_params=None, custom_obj={}, extract_to="models"
     ):
@@ -87,8 +93,10 @@ class Builder:
         if self.model_path is None:
             self.load_pretrained_network(arch=arch)
         if str(self.model_path).split(".")[-1] == "zip":
-            self.unzip_model_files(extract_to=extract_to) # ./models | ./models/ensemble
-        model_basename = os.path.basename(self.model_path.rstrip('/'))
+            self.unzip_model_files(
+                extract_to=extract_to
+            )  # ./models | ./models/ensemble
+        model_basename = os.path.basename(self.model_path.rstrip("/"))
         if model_basename != self.name:
             # look through subdirectories for saved model folder matching "self.name"
             for root, dirs, _ in os.walk(self.model_path):
@@ -104,7 +112,7 @@ class Builder:
         except Exception as e:
             self.log.error(e)
         return self.model
-    
+
     def load_pretrained_network(self, arch=None):
         err = None
         if arch is None:
@@ -115,12 +123,11 @@ class Builder:
             self.log.error(err)
             sys.exit(1)
         model_src = "spacekit.builder.trained_networks"
-        archive_file = f"{arch}.zip" # calmodels.zip | ensemble.zip
+        archive_file = f"{arch}.zip"  # calmodels.zip | ensemble.zip
         with importlib.resources.path(model_src, archive_file) as mod:
             self.model_path = mod
         if arch == "calmodels" and self.blueprint is None:
             self.blueprint = self.name
-
 
     def unzip_model_files(self, extract_to="models"):
         """Extracts a keras model object from a zip archive
@@ -462,7 +469,13 @@ class BuilderMLP(Builder):
     """
 
     def __init__(
-        self, X_train=None, y_train=None, X_test=None, y_test=None, blueprint="mlp", **builder_kwargs
+        self,
+        X_train=None,
+        y_train=None,
+        X_test=None,
+        y_test=None,
+        blueprint="mlp",
+        **builder_kwargs,
     ):
         train_data = (
             (X_train, y_train) if X_train is not None and y_train is not None else None
@@ -471,7 +484,10 @@ class BuilderMLP(Builder):
             (X_test, y_test) if X_test is not None and y_test is not None else None
         )
         super().__init__(
-            train_data=train_data, test_data=test_data, logname="BuilderMLP", **builder_kwargs
+            train_data=train_data,
+            test_data=test_data,
+            logname="BuilderMLP",
+            **builder_kwargs,
         )
         self.blueprint = blueprint
         self.name = "sequential_mlp"
@@ -572,7 +588,13 @@ class BuilderCNN3D(Builder):
     """
 
     def __init__(
-        self, X_train=None, y_train=None, X_test=None, y_test=None, blueprint="cnn3d", **builder_kwargs
+        self,
+        X_train=None,
+        y_train=None,
+        X_test=None,
+        y_test=None,
+        blueprint="cnn3d",
+        **builder_kwargs,
     ):
         train_data = (
             (X_train, y_train) if X_train is not None and y_train is not None else None
@@ -581,7 +603,10 @@ class BuilderCNN3D(Builder):
             (X_test, y_test) if X_test is not None and y_test is not None else None
         )
         super().__init__(
-            train_data=train_data, test_data=test_data, logname="BuilderCNN3D", **builder_kwargs
+            train_data=train_data,
+            test_data=test_data,
+            logname="BuilderCNN3D",
+            **builder_kwargs,
         )
         self.blueprint = blueprint
         self.input_shape = X_train.shape[1:] if X_train is not None else None
@@ -735,7 +760,10 @@ class BuilderEnsemble(Builder):
             (X_test, y_test) if X_test is not None and y_test is not None else None
         )
         super().__init__(
-            train_data=train_data, test_data=test_data, logname="BuilderEnsemble", **builder_kwargs
+            train_data=train_data,
+            test_data=test_data,
+            logname="BuilderEnsemble",
+            **builder_kwargs,
         )
         self.name = "ensembleSVM"
         self.input_name = input_name
@@ -914,7 +942,13 @@ class BuilderCNN2D(Builder):
     """
 
     def __init__(
-        self, X_train=None, y_train=None, X_test=None, y_test=None, blueprint="cnn2d", **builder_kwargs,
+        self,
+        X_train=None,
+        y_train=None,
+        X_test=None,
+        y_test=None,
+        blueprint="cnn2d",
+        **builder_kwargs,
     ):
         train_data = (
             (X_train, y_train) if X_train is not None and y_train is not None else None
@@ -923,7 +957,10 @@ class BuilderCNN2D(Builder):
             (X_test, y_test) if X_test is not None and y_test is not None else None
         )
         super().__init__(
-            train_data=train_data, test_data=test_data, logname="BuilderCNN2D", **builder_kwargs
+            train_data=train_data,
+            test_data=test_data,
+            logname="BuilderCNN2D",
+            **builder_kwargs,
         )
         self.blueprint = blueprint
         self.input_shape = self.X_train.shape[1:] if self.X_train else None
@@ -1071,7 +1108,7 @@ class MemoryClassifier(BuilderMLP):
         y_test=None,
         blueprint="mem_clf",
         test_idx=None,
-        **builder_kwargs
+        **builder_kwargs,
     ):
         train_data = (
             (X_train, y_train) if X_train is not None and y_train is not None else None
@@ -1080,7 +1117,11 @@ class MemoryClassifier(BuilderMLP):
             (X_test, y_test) if X_test is not None and y_test is not None else None
         )
         super().__init__(
-            train_data=train_data, test_data=test_data, blueprint=blueprint, logname="MemoryClassifier", **builder_kwargs
+            train_data=train_data,
+            test_data=test_data,
+            blueprint=blueprint,
+            logname="MemoryClassifier",
+            **builder_kwargs,
         )
         self.input_shape = self.X_train.shape[1] if self.X_train else 9
         self.output_shape = 4
@@ -1115,7 +1156,7 @@ class MemoryRegressor(BuilderMLP):
         y_test=None,
         blueprint="mem_reg",
         test_idx=None,
-        **builder_kwargs
+        **builder_kwargs,
     ):
         train_data = (
             (X_train, y_train) if X_train is not None and y_train is not None else None
@@ -1124,7 +1165,11 @@ class MemoryRegressor(BuilderMLP):
             (X_test, y_test) if X_test is not None and y_test is not None else None
         )
         super().__init__(
-            train_data=train_data, test_data=test_data, blueprint=blueprint, logname="MemoryRegressor", **builder_kwargs,
+            train_data=train_data,
+            test_data=test_data,
+            blueprint=blueprint,
+            logname="MemoryRegressor",
+            **builder_kwargs,
         )
         self.input_shape = self.X_train.shape[1] if self.X_train else 9
         self.output_shape = 1
@@ -1159,7 +1204,7 @@ class WallclockRegressor(BuilderMLP):
         y_test=None,
         blueprint="wall_reg",
         test_idx=None,
-        **builder_kwargs
+        **builder_kwargs,
     ):
         train_data = (
             (X_train, y_train) if X_train is not None and y_train is not None else None
@@ -1168,7 +1213,11 @@ class WallclockRegressor(BuilderMLP):
             (X_test, y_test) if X_test is not None and y_test is not None else None
         )
         super().__init__(
-            train_data=train_data, test_data=test_data, blueprint=blueprint, logname="WallclockRegressor", **builder_kwargs,
+            train_data=train_data,
+            test_data=test_data,
+            blueprint=blueprint,
+            logname="WallclockRegressor",
+            **builder_kwargs,
         )
         self.input_shape = self.X_train.shape[1] if self.X_train else 9
         self.output_shape = 1

--- a/spacekit/datasets/_base.py
+++ b/spacekit/datasets/_base.py
@@ -1,7 +1,6 @@
 """
 Base IO code for all datasets (borrowing concepts from sklearn.datasets and keras.utils.load_data)
 """
-from importlib import resources
 from spacekit.extractor.scrape import WebScraper
 from spacekit.analyzer.scan import import_dataset, CalScanner, SvmScanner
 from spacekit.datasets.meta import spacekit_collections

--- a/spacekit/datasets/beam.py
+++ b/spacekit/datasets/beam.py
@@ -37,7 +37,7 @@ S3PREFIX = os.environ.get("PFX", "archive")
 
 def download(scrape="file:data", datasets="2022-02-14,2021-11-04,2021-10-28", dest="."):
     if len(dest.split("/")) > 1:
-        cache_dir =  os.path.abspath(dest.split("/")[0])
+        cache_dir = os.path.abspath(dest.split("/")[0])
         cache_subdir = "/".join(dest.split("/")[1:])
     else:
         cache_dir, cache_subdir = dest, "data"
@@ -48,26 +48,37 @@ def download(scrape="file:data", datasets="2022-02-14,2021-11-04,2021-10-28", de
             SPACEKIT_LOG.info("Scraping web via custom json file")
             with open(archive, "r") as j:
                 collection = json.load(j)
-                scraper = WebScraper(collection["uri"], collection["data"], cache_dir=cache_dir, cache_subdir=cache_subdir)
+                scraper = WebScraper(
+                    collection["uri"],
+                    collection["data"],
+                    cache_dir=cache_dir,
+                    cache_subdir=cache_subdir,
+                )
         elif archive in spacekit_collections.keys():
             SPACEKIT_LOG.info(f"Scraping spacekit collection {archive.upper()}")
             cc = spacekit_collections[archive]  # "calcloud", "svm"
             dd = {}
             for d in datasets:
                 dd[d] = cc["data"][d]
-            scraper = WebScraper(cc["uri"], dd, cache_dir=cache_dir, cache_subdir=cache_subdir)
+            scraper = WebScraper(
+                cc["uri"], dd, cache_dir=cache_dir, cache_subdir=cache_subdir
+            )
         else:
             SPACEKIT_LOG.error(
                 f"Must use custom json file or one of the spacekit collections: {list(spacekit_collections.keys())}"
             )
     elif src == "s3":
         SPACEKIT_LOG.info("Scraping S3")
-        scraper = S3Scraper(archive, pfx=S3PREFIX, cache_dir=cache_dir, cache_subdir=cache_subdir)
+        scraper = S3Scraper(
+            archive, pfx=S3PREFIX, cache_dir=cache_dir, cache_subdir=cache_subdir
+        )
         scraper.make_s3_keys(fnames=datasets)
     elif src == "file":
         SPACEKIT_LOG.info("Scraping local directory")
         p = [f"{archive}/*.zip", f"{archive}/*"]
-        scraper = FileScraper(patterns=p, clean=False, cache_dir=cache_dir, cache_subdir=cache_subdir)
+        scraper = FileScraper(
+            patterns=p, clean=False, cache_dir=cache_dir, cache_subdir=cache_subdir
+        )
     if scraper:
         try:
             scraper.scrape()

--- a/spacekit/datasets/meta.py
+++ b/spacekit/datasets/meta.py
@@ -1,5 +1,5 @@
 calcloud = {
-    "uri": "https://zenodo.org/record/7833961/files",
+    "uri": "https://zenodo.org/record/7839172/files",
     "data": {
         "2022-02-14": {
             "fname": "hst_cal_std_2022-02-14.zip?download=1",
@@ -40,7 +40,7 @@ calcloud = {
 }
 
 svm = {
-    "uri": "https://zenodo.org/record/7833961/files",
+    "uri": "https://zenodo.org/record/7839172/files",
     "data": {
         "2022-02-14": {
             "fname": "hst_drz_svm_2022-02-14.zip?download=1",
@@ -88,7 +88,7 @@ svm = {
 }
 
 k2 = {
-    "uri": "https://zenodo.org/record/7833961/files",
+    "uri": "https://zenodo.org/record/7839172/files",
     "data": {
         "test": {
             "fname": "k2-exo-flux-ts-test.csv.zip?download=1",

--- a/spacekit/datasets/meta.py
+++ b/spacekit/datasets/meta.py
@@ -6,28 +6,28 @@ calcloud = {
             "hash": "7522ec6bdaffaa06827e9ec9781b5182",
             "desc": "data, model and training results",
             "key": "2022-02-14-1644848448",
-            "size": "12.9MB"
+            "size": "12.9MB",
         },
         "2021-11-04": {
             "fname": "hst_cal_std_2021-11-04.zip?download=1",
             "hash": "d1ba4329ee18219e1a562d7a72c96368",
             "desc": "data, model and training results",
             "key": "2021-11-04-1636048291",
-            "size": "11.6MB"
+            "size": "11.6MB",
         },
         "2021-10-28": {
             "fname": "hst_cal_std_2021-10-28.zip?download=1",
             "hash": "09fe043a61165def660ca0209a4c562e",
             "desc": "data, model and training results",
             "key": "2021-10-28-1635457222",
-            "size": "8.6MB"
+            "size": "8.6MB",
         },
         "2021-08-22": {
             "fname": "hst_cal_std_2021-08-22.zip?download=1",
             "hash": "2ac4857954ddcd384c43a9a0dd8d7cff",
             "desc": "data, model and training results",
             "key": "2021-08-22-1629663047",
-            "size": "6MB"
+            "size": "6MB",
         },
     },
     "model": {
@@ -35,7 +35,7 @@ calcloud = {
         "hash": "101e86c6fbacd0480c8bd307685c2730",
         "desc": "hst calcloud resource prediction models",
         "key": "calmodels",
-        "size": "2.1MB"
+        "size": "2.1MB",
     },
 }
 
@@ -47,43 +47,43 @@ svm = {
             "hash": "c0590ee3277aa1f2607a0d9ad827db27",
             "desc": "latest model, data and training results",
             "key": "2022-02-14-1644850390",
-            "size": "18MB"
+            "size": "18MB",
         },
         "2022-01-30": {
             "fname": "hst_drz_svm_2022-01-30.zip?download=1",
             "hash": "758334cf0f4e80038e2f966ac5c044a1",
             "desc": "retrained model, data and training results",
             "key": "2022-01-30-1643523529",
-            "size": "18MB"
+            "size": "18MB",
         },
         "2022-01-16": {
             "fname": "hst_drz_svm_2022-01-16.zip?download=1",
             "hash": "8c0e87943afeb62404df0d2e529051d6",
             "desc": "baseline model, data and training results",
             "key": "2022-01-16-1642337739",
-            "size": "34.1kB"
+            "size": "34.1kB",
         },
         "2021-07-28": {
             "fname": "svm_labeled_2021-07-28.csv?download=1",
             "hash": "29fe3fde4e0f826e8c6d4b85a21a3690",
             "desc": "labeled test set created 07-28-2021 for drizzlepac 3.3.1",
             "key": "svm_labeled_2021-07-28.csv",
-            "size": "179.1kB"
+            "size": "179.1kB",
         },
         "2021-10-06": {
             "fname": "svm_unlabeled_2021-10-06.csv?download=1",
             "hash": "2979fd5b0e24663ce0ae8ff93ebd1ca1",
             "desc": "unlabeled test set created 10-6-2021 for drizzlepac 3.3.1",
             "key": "svm_unlabeled_2021-10-06.csv",
-            "size": "102kB"
-        }
+            "size": "102kB",
+        },
     },
     "model": {
         "fname": "ensemble.zip",
         "hash": "a2122a76fd293c542bf25c3e4437960d",
         "desc": "hst svm alignment prediction models",
         "key": "ensemble",
-        "size": "17.9MB"
+        "size": "17.9MB",
     },
 }
 
@@ -95,14 +95,14 @@ k2 = {
             "hash": "02646070957656c38c6c9dff66552684",
             "desc": "k2 flux time series test set",
             "key": "exoTest.csv",
-            "size": "5.8MB"
+            "size": "5.8MB",
         },
         "train": {
             "fname": "k2-exo-flux-ts-train.csv.zip?download=1",
             "hash": "f26bcc2dbc30544678e0c15c1a67fe6b",
             "desc": "k2 flux time series training set",
             "key": "exoTrain.csv",
-            "size": "51.7MB"
+            "size": "51.7MB",
         },
     },
 }
@@ -115,12 +115,12 @@ networks = {
         "basepath": "spacekit.builder.trained_networks",
         "fname": "calmodels.zip",
         "hash": "000378942a1dcb662590ac6d911b8ba1e59d54248254d23e03427bb048597298",
-        "size": "2.1MB"
+        "size": "2.1MB",
     },
     "svm": {
         "basepath": "spacekit.builder.trained_networks",
         "fname": "ensemble.zip",
         "hash": "9ef2b5ddd078544c98a19e2c26fcccb34ae36c742b86ee3b9434ceab6270c07d",
-        "size": "17.9MB"
+        "size": "17.9MB",
     },
 }

--- a/spacekit/extractor/scrape.py
+++ b/spacekit/extractor/scrape.py
@@ -92,7 +92,14 @@ class Scraper:
     """Parent Class for various data scraping subclasses. Instantiating the appropriate subclass is preferred."""
 
     def __init__(
-        self, cache_dir="~", cache_subdir="data", format="zip", extract=True, clean=True, name="Scraper", **log_kws
+        self,
+        cache_dir="~",
+        cache_subdir="data",
+        format="zip",
+        extract=True,
+        clean=True,
+        name="Scraper",
+        **log_kws,
     ):
         """Instantiates a spacekit.extractor.scrape.Scraper object.
 
@@ -195,7 +202,7 @@ class FileScraper(Scraper):
         extract=True,
         clean=False,
         name="FileScraper",
-        **log_kws
+        **log_kws,
     ):
         """Instantiates a spacekit.extractor.scrape.FileScraper object.
 
@@ -259,7 +266,7 @@ class WebScraper(Scraper):
         format="zip",
         extract=True,
         clean=True,
-        **log_kws
+        **log_kws,
     ):
         """Uses dictionary of uri, filename and hash key-value pairs to download data securely from a website such as Github.
 
@@ -309,7 +316,7 @@ class WebScraper(Scraper):
                 archive_format=self.format,
             )
             extracted = os.path.join(os.path.dirname(fpath), data["key"])
-            #extracted = str(os.path.relpath(fpath)).split(".")[0]
+            # extracted = str(os.path.relpath(fpath)).split(".")[0]
             self.fpaths.append(os.path.relpath(extracted))
             if self.clean is True and os.path.exists(
                 extracted
@@ -360,7 +367,7 @@ class S3Scraper(Scraper):
             format=format,
             extract=extract,
             name="S3Scraper",
-            **log_kws
+            **log_kws,
         )
         self.bucket = bucket
         self.pfx = pfx
@@ -370,17 +377,16 @@ class S3Scraper(Scraper):
         self.s3 = boto3.resource("s3", config=retry_config)
         self.client = boto3.client("s3", config=retry_config)
         self.aws_kwargs = self.authorize_aws()
-    
+
     def authorize_aws(self):
         self.aws_kwargs = dict(
-            region_name = os.environ.get("AWS_REGION_NAME", "us-east-1"),
-            aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", ""),
-            aws_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
-            aws_session_token = os.environ.get("AWS_SESSION_TOKEN", "")
-            )
+            region_name=os.environ.get("AWS_REGION_NAME", "us-east-1"),
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", ""),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
+            aws_session_token=os.environ.get("AWS_SESSION_TOKEN", ""),
+        )
         self.s3 = boto3.resource("s3", config=retry_config, **self.aws_kwargs)
         self.client = boto3.client("s3", config=retry_config, **self.aws_kwargs)
-
 
     def make_s3_keys(
         self,
@@ -408,7 +414,7 @@ class S3Scraper(Scraper):
             fname = key + ".zip"
             self.dataset[key] = {"fname": fname, "pfx": self.pfx}
         return self.dataset
-    
+
     def scrape_s3_file(self, fpath, obj):
         with open(fpath, "wb") as f:
             self.client.download_fileobj(self.bucket, obj, f)
@@ -486,9 +492,9 @@ class S3Scraper(Scraper):
         except Exception as e:
             self.log.error(e)
             sys.exit(3)
-        self.log.debug(f"Input data scraped successfully.")
+        self.log.debug("Input data scraped successfully.")
         return input_data
-   
+
 
 class DynamoDBScraper(Scraper):
     def __init__(
@@ -502,7 +508,7 @@ class DynamoDBScraper(Scraper):
         format="zip",
         extract=True,
         clean=True,
-        **log_kws
+        **log_kws,
     ):
         super().__init__(
             cache_dir=cache_dir,
@@ -657,7 +663,6 @@ class DynamoDBScraper(Scraper):
 
 
 class FitsScraper(FileScraper):
-
     def __init__(self, data, input_path, **log_kws):
         super().__init__(name="FitsScraper", **log_kws)
         self.df = data.copy()
@@ -699,7 +704,9 @@ class FitsScraper(FileScraper):
 class MastScraper:
     """Class for scraping metadata from MAST (Mikulsky Archive for Space Telescopes) via ``astroquery``. Current functionality for this class is limited to extracting the `target_classification` values of HAP targets from the archive. An example of a target classification is "GALAXY" - an alphanumeric categorization of an image product/.fits file. Note - the files themselves are not downloaded, just this specific metadata listed in the online archive database. For downloading MAST science files, use the ``spacekit.extractor.radio`` module. The search parameter values needed for locating a HAP product on MAST can be extracted from the fits science extension headers using the ``astropy`` library. See the ``spacekit.preprocessor.scrub`` api for an example (or the astropy documentation)."""
 
-    def __init__(self, df, trg_col="targname", ra_col="ra_targ", dec_col="dec_targ", **log_kws):
+    def __init__(
+        self, df, trg_col="targname", ra_col="ra_targ", dec_col="dec_targ", **log_kws
+    ):
         """Instantiates a spacekit.extractor.scrape.MastScraper object.
 
         Parameters
@@ -726,7 +733,6 @@ class MastScraper:
         self.target_categories = {}
         self.other_cat = {}
         self.categories = {}
-
 
     def scrape_mast(self):
         """Main calling function to scrape MAST
@@ -895,10 +901,13 @@ class JsonScraper(FileScraper):
         store_h5=True,
         h5_file=None,
         output_path=None,
-        **log_kws
+        **log_kws,
     ):
         super().__init__(
-            search_path=search_path, search_patterns=search_patterns, name="JsonScraper", **log_kws
+            search_path=search_path,
+            search_patterns=search_patterns,
+            name="JsonScraper",
+            **log_kws,
         )
         self.file_basename = file_basename
         self.crpt = crpt

--- a/spacekit/extractor/scrape.py
+++ b/spacekit/extractor/scrape.py
@@ -817,7 +817,7 @@ class MastScraper:
                 self.categories[i] = v
         self.categories.update(self.other_cat)
         cat = pd.DataFrame.from_dict(
-            self.categories, orient="index", columns={"category"}
+            self.categories, orient="index", columns=["category"]
         )
         self.log.info("\nTarget Categories Assigned.")
         self.log.info(cat["category"].value_counts())

--- a/spacekit/extractor/utils.py
+++ b/spacekit/extractor/utils.py
@@ -1,0 +1,39 @@
+import os
+from zipfile import ZipFile
+from tarfile import TarFile
+
+
+def is_within_directory(directory, target):
+    abs_directory = os.path.abspath(directory)
+    abs_target = os.path.abspath(target)
+    prefix = os.path.commonprefix([abs_directory, abs_target])
+    return prefix == abs_directory
+
+def safe_extract(tar, expath=".", members=None, *, numeric_owner=False):
+    directory = os.path.dirname(tar)
+    for member in tar.getmembers():
+        member_path = os.path.join(directory, member.name)
+        if not is_within_directory(directory, member_path):
+            raise Exception("WARNING: Attempted Path Traversal in Tar File")
+    
+    tar.extractall(expath, members, numeric_owner=numeric_owner)
+
+def extract_file(fpath, dest="."):
+    fp = fpath.split(".")
+    if len(fp) > 2:
+        mode = f"r:{fp[-1]}"
+        kind = fp[-2]
+    else:
+        kind = fp[-1]
+        mode = "r"
+    if kind == "zip":
+        with ZipFile(fpath, mode) as zip_ref:
+            zip_ref.extractall(dest)
+    elif kind == "tar":
+        with TarFile.open(fpath, mode) as tar:
+            safe_extract(tar, expath=dest)
+    else:
+        raise Exception(f"Could not extract file of type {kind}")
+
+
+    

--- a/spacekit/extractor/utils.py
+++ b/spacekit/extractor/utils.py
@@ -9,14 +9,16 @@ def is_within_directory(directory, target):
     prefix = os.path.commonprefix([abs_directory, abs_target])
     return prefix == abs_directory
 
+
 def safe_extract(tar, expath=".", members=None, *, numeric_owner=False):
     directory = os.path.dirname(tar)
     for member in tar.getmembers():
         member_path = os.path.join(directory, member.name)
         if not is_within_directory(directory, member_path):
             raise Exception("WARNING: Attempted Path Traversal in Tar File")
-    
+
     tar.extractall(expath, members, numeric_owner=numeric_owner)
+
 
 def extract_file(fpath, dest="."):
     fp = fpath.split(".")
@@ -34,6 +36,3 @@ def extract_file(fpath, dest="."):
             safe_extract(tar, expath=dest)
     else:
         raise Exception(f"Could not extract file of type {kind}")
-
-
-    

--- a/spacekit/logger/log.py
+++ b/spacekit/logger/log.py
@@ -65,7 +65,9 @@ class Logger:
         verbose=False,
         log=None,
     ):
-        self.__name__ = f"spacekit.{script_name}" if script_name != "spacekit" else script_name
+        self.__name__ = (
+            f"spacekit.{script_name}" if script_name != "spacekit" else script_name
+        )
         self.short_name = script_name
         self.console = console
         self.logfile = logfile
@@ -87,18 +89,22 @@ class Logger:
         self.verbose = verbose
         self.log = log
         self.log_line_template = self.set_log_line_template()
-    
+
     def set_name(self):
         if self.verbose is True:
             name = (
-                " [%(threadName)s - %(name)-16s]" if self.threadname is True else " [%(name)-16s]"
+                " [%(threadName)s - %(name)-16s]"
+                if self.threadname is True
+                else " [%(name)-16s]"
             )
         else:
-            name =  (
-                " [%(threadName)s - %(name)s]" if self.threadname is True else " [%(name)s]"
+            name = (
+                " [%(threadName)s - %(name)s]"
+                if self.threadname is True
+                else " [%(name)s]"
             )
         return name
-    
+
     def set_log_line_template(self):
         start_template = "%(color_on)s"
         timestamp = "[%(asctime)s]" if self.asctime is True else "[%(created)d]"
@@ -190,7 +196,6 @@ class Logger:
             print("Failed to modify handlers.")
         return logger
 
-
     def setup_logger(self, logger=None):
         self.set_formatters()
         # Create logger
@@ -205,8 +210,8 @@ class Logger:
             logger = self.update_handlers(logger)
         else:
             logger = self.add_handlers(logger)
-            
-        if self.verbose: # identify source module in each log statement
+
+        if self.verbose:  # identify source module in each log statement
             logger = logger.getChild(self.short_name)
             logger.name = self.__name__[:16]
 
@@ -218,7 +223,7 @@ class Logger:
         if self.log:
             logger = self.setup_logger(logger=self.log)
         else:
-        # Called by submodules (not scripts)
+            # Called by submodules (not scripts)
             logger = self.setup_logger()
         return logger
 

--- a/spacekit/preprocessor/encode.py
+++ b/spacekit/preprocessor/encode.py
@@ -277,7 +277,7 @@ class SvmEncoder:
             c = cat.split(sep)[0]
             if c in ckeys:
                 CAT[idx] = ckeys[c]
-        df_cat = pd.DataFrame.from_dict(CAT, orient="index", columns={"category"})
+        df_cat = pd.DataFrame.from_dict(CAT, orient="index", columns=["category"])
         self.df.drop("category", axis=1, inplace=True)
         self.df = self.df.join(df_cat, how="left")
         return self.df

--- a/spacekit/preprocessor/scrub.py
+++ b/spacekit/preprocessor/scrub.py
@@ -153,7 +153,7 @@ class SvmScrubber(Scrubber):
         make_pos_list=True,
         crpt=0,
         make_subsamples=False,
-        **log_kws
+        **log_kws,
     ):
         self.col_order = self.set_col_order()
         super().__init__(
@@ -164,7 +164,7 @@ class SvmScrubber(Scrubber):
             dropnans=dropnans,
             save_raw=save_raw,
             name="SVMScrubber",
-            **log_kws
+            **log_kws,
         )
 
         self.input_path = input_path
@@ -417,7 +417,7 @@ class CalScrubber(Scrubber):
         output_file="batch.csv",
         dropnans=True,
         save_raw=True,
-        **log_kws
+        **log_kws,
     ):
         super().__init__(
             data=data,
@@ -450,9 +450,9 @@ class CalScrubber(Scrubber):
 
     def scrub_inputs(self):
         self.log.info(f"Scrubbing inputs for {self.data.index[0]}")
-        n_files = int(self.data['n_files'][0])
-        total_mb = int(np.round(float(self.data['total_mb']), 0))
-        detector = 1 if self.data["DETECTOR"][0].upper() in ["UVIS","WFC"] else 0
+        n_files = int(self.data["n_files"][0])
+        total_mb = int(np.round(float(self.data["total_mb"]), 0))
+        detector = 1 if self.data["DETECTOR"][0].upper() in ["UVIS", "WFC"] else 0
         subarray = 1 if self.data["SUBARRAY"][0].title() == "True" else 0
         drizcorr = 1 if self.data["DRIZCORR"][0].upper() == "PERFORM" else 0
         pctecorr = 1 if self.data["PCTECORR"][0].upper() == "PERFORM" else 0
@@ -472,4 +472,16 @@ class CalScrubber(Scrubber):
         for k, v in instr_key.items():
             if i[0] == k:
                 instr = v
-        return np.array([n_files, total_mb, drizcorr, pctecorr, crsplit, subarray, detector, dtype, instr])
+        return np.array(
+            [
+                n_files,
+                total_mb,
+                drizcorr,
+                pctecorr,
+                crsplit,
+                subarray,
+                detector,
+                dtype,
+                instr,
+            ]
+        )

--- a/spacekit/preprocessor/transform.py
+++ b/spacekit/preprocessor/transform.py
@@ -22,7 +22,7 @@ class Transformer:
         rename="_scl",
         output_path=None,
         name="Transformer",
-        **log_kws
+        **log_kws,
     ):
         """Instantiates a Transformer class object. Unless the `cols` attribute is empty, it will automatically instantiate some of the other attributes needed to transform the data. Using the Transformer subclasses instead is recommended (this class is mainly used as an object with general methods to load or save the transform data as well as instantiate some of the initial attributes).
 
@@ -173,7 +173,9 @@ class Transformer:
         try:
             idx = self.data.index
         except AttributeError:
-            self.log.error("Non-dataframe type detected - Trying `normalized_matrix` instead.")
+            self.log.error(
+                "Non-dataframe type detected - Trying `normalized_matrix` instead."
+            )
             return self.normalized_matrix(normalized)
         if self.rename is None:
             newcols = self.cols
@@ -233,7 +235,9 @@ class Transformer:
         elif isinstance(self.data, np.ndarray):
             return self.normalized_matrix(normalized)
         else:
-            self.log.error("Input data type not recognized - must be a dataframe or array")
+            self.log.error(
+                "Input data type not recognized - must be a dataframe or array"
+            )
             return None
 
 
@@ -262,7 +266,7 @@ class PowerX(Transformer):
         output_path=None,
         join_data=1,
         rename="_scl",
-        **log_kws
+        **log_kws,
     ):
         super().__init__(
             data,
@@ -275,7 +279,7 @@ class PowerX(Transformer):
             rename=rename,
             output_path=output_path,
             name="PowerX",
-            **log_kws
+            **log_kws,
         )
         self.calculate_power()
         self.normalized = self.apply_power_matrix()

--- a/spacekit/skopes/hst/cal/config.py
+++ b/spacekit/skopes/hst/cal/config.py
@@ -15,20 +15,12 @@ COLUMN_ORDER = {
         "dtype",
         "instr",
     ],
-    "svm": [
-
-    ]
+    "svm": [],
 }
 
-NORM_COLS = {
-    "asn": ["n_files", "total_mb"],
-    "svm": []
-}
+NORM_COLS = {"asn": ["n_files", "total_mb"], "svm": []}
 
-RENAME_COLS = {
-    "asn": ["x_files", "x_size"],
-    "svm": []
-}
+RENAME_COLS = {"asn": ["x_files", "x_size"], "svm": []}
 
 X_NORM = {
     "asn": [

--- a/spacekit/skopes/hst/cal/predict.py
+++ b/spacekit/skopes/hst/cal/predict.py
@@ -43,16 +43,26 @@ from spacekit.logger.log import SPACEKIT_LOG, Logger
 # MODEL_PATH = os.environ.get("MODEL_PATH", "./models") #"data/2022-02-14-1644848448/models"
 # TX_FILE = os.path.join(MODEL_PATH, "tx_data.json")
 
+
 def load_pretrained_model(**builder_kwargs):
     builder = Builder(**builder_kwargs)
     builder.load_saved_model(arch="calmodels")
     return builder
 
-class Predict:
 
+class Predict:
     def __init__(
-        self, dataset, bucket_name=None, key=None, model_path=None, models={}, tx_file=None, norm=1, norm_cols=[0,1], **log_kws
-        ):
+        self,
+        dataset,
+        bucket_name=None,
+        key=None,
+        model_path=None,
+        models={},
+        tx_file=None,
+        norm=1,
+        norm_cols=[0, 1],
+        **log_kws,
+    ):
         self.dataset = dataset
         self.bucket_name = bucket_name
         self.key = "control" if key is None else key
@@ -74,18 +84,22 @@ class Predict:
         self.predictions = None
         self.probabilities = None
         self.initialize_models()
-    
+
     def initialize_models(self):
         self.log.info("Initializing prediction models")
         if self.models is None and not os.path.exists(self.model_path):
-            self.log.warning(f"models path not found: {self.model_path} - defaulting to latest in spacekit-collection")
+            self.log.warning(
+                f"models path not found: {self.model_path} - defaulting to latest in spacekit-collection"
+            )
             self.model_path = None
         self.load_models(models=self.models)
 
     def scrape_s3_inputs(self):
         if self.key == "control":
             self.key = f"control/{self.dataset}/{self.dataset}_MemModelFeatures.txt"
-        self.input_data = S3Scraper(bucket=self.bucket_name, pfx=self.key, **self.log_kws).import_dataset()
+        self.input_data = S3Scraper(
+            bucket=self.bucket_name, pfx=self.key, **self.log_kws
+        ).import_dataset()
 
     def normalize_inputs(self):
         if self.norm:
@@ -104,14 +118,31 @@ class Predict:
             self.scrape_s3_inputs()
         self.log.info(f"dataset: {self.dataset} keys: {self.input_data}")
         self.log.info("Preprocessing features")
-        self.inputs = CalScrubber(data={self.dataset:self.input_data}, **self.log_kws).scrub_inputs()
+        self.inputs = CalScrubber(
+            data={self.dataset: self.input_data}, **self.log_kws
+        ).scrub_inputs()
         self.log.info(f"dataset: {self.dataset} features: {self.inputs}")
         self.normalize_inputs()
 
     def load_models(self, models={}):
-        self.mem_clf = models.get('mem_clf', load_pretrained_model(model_path=self.model_path, name="mem_clf", **self.log_kws))
-        self.wall_reg = models.get('wall_reg', load_pretrained_model(model_path=self.model_path, name="wall_reg", **self.log_kws))
-        self.mem_reg = models.get('mem_reg', load_pretrained_model(model_path=self.model_path, name="mem_reg", **self.log_kws))
+        self.mem_clf = models.get(
+            "mem_clf",
+            load_pretrained_model(
+                model_path=self.model_path, name="mem_clf", **self.log_kws
+            ),
+        )
+        self.wall_reg = models.get(
+            "wall_reg",
+            load_pretrained_model(
+                model_path=self.model_path, name="wall_reg", **self.log_kws
+            ),
+        )
+        self.mem_reg = models.get(
+            "mem_reg",
+            load_pretrained_model(
+                model_path=self.model_path, name="mem_reg", **self.log_kws
+            ),
+        )
         if self.model_path is None:
             self.model_path = os.path.dirname(self.mem_clf.model_path)
         if self.tx_file is None or not os.path.exists(self.tx_file):
@@ -151,25 +182,31 @@ def local_handler(dataset, **kwargs):
 
 
 def lambda_handler(event, context):
-    """Predict Resource Allocation requirements for memory (GB) and max execution `kill time` / `wallclock` (seconds) using three pre-trained neural networks. This lambda is invoked from the Job Submit lambda which json.dumps the s3 bucket and key to the file containing job input parameters. The path to the text file in s3 assumes the following format: `control/ipppssoot/ipppssoot_MemModelFeatures.txt`.
-    """
-    MODEL_PATH = os.environ.get("MODEL_PATH", "./models") #"data/2022-02-14-1644848448/models"
+    """Predict Resource Allocation requirements for memory (GB) and max execution `kill time` / `wallclock` (seconds) using three pre-trained neural networks. This lambda is invoked from the Job Submit lambda which json.dumps the s3 bucket and key to the file containing job input parameters. The path to the text file in s3 assumes the following format: `control/ipppssoot/ipppssoot_MemModelFeatures.txt`."""
+    MODEL_PATH = os.environ.get(
+        "MODEL_PATH", "./models"
+    )  # "data/2022-02-14-1644848448/models"
     TX_FILE = os.path.join(MODEL_PATH, "tx_data.json")
     # load models here for warm starts in aws lambda
     mem_clf = load_pretrained_model(model_path=MODEL_PATH, name="mem_clf")
     wall_reg = load_pretrained_model(model_path=MODEL_PATH, name="wall_reg")
     mem_reg = load_pretrained_model(model_path=MODEL_PATH, name="mem_reg")
-    models=dict(mem_clf=mem_clf, wall_reg=wall_reg, mem_reg=mem_reg)
+    models = dict(mem_clf=mem_clf, wall_reg=wall_reg, mem_reg=mem_reg)
     # import and prep data: control/dataset/dataset_MemModelFeatures.txt
-    pred = Predict(event["Dataset"], bucket_name=event["Bucket"], key=event["Key"], models=models, tx_file=TX_FILE)
+    pred = Predict(
+        event["Dataset"],
+        bucket_name=event["Bucket"],
+        key=event["Key"],
+        models=models,
+        tx_file=TX_FILE,
+    )
     pred.run_inference()
     return pred.predictions
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        prog="spacekit",
-        usage="spacekit.skopes.hst.cal.predict dataset"
+        prog="spacekit", usage="spacekit.skopes.hst.cal.predict dataset"
     )
     parser.add_argument(
         "dataset",
@@ -202,44 +239,40 @@ if __name__ == "__main__":
         "--norm_cols",
         type=str,
         default="0,1",
-        help="comma-separated index of input columns to apply normalization"
+        help="comma-separated index of input columns to apply normalization",
     )
     parser.add_argument(
         "-m",
         "--model_path",
         type=str,
         default=os.environ.get("MODEL_PATH", None),
-        help="path to saved model directory"
+        help="path to saved model directory",
     )
     parser.add_argument(
         "-t",
         "--tx_file",
         type=str,
         default=None,
-        help="path to transformer metadata json file"
+        help="path to transformer metadata json file",
     )
     parser.add_argument(
         "--console_log_level",
         type=str,
         choices=["info", "debug", "error", "warning"],
-        default="info"
+        default="info",
     )
     parser.add_argument(
         "--logfile_log_level",
         type=str,
         choices=["info", "debug", "error", "warning"],
-        default="debug"
+        default="debug",
     )
     parser.add_argument(
         "--logfile",
         type=bool,
         default=True,
     )
-    parser.add_argument(
-        "--logdir",
-        type=str,
-        default="."
-    )
+    parser.add_argument("--logdir", type=str, default=".")
     parser.add_argument(
         "--verbose",
         "-v",

--- a/spacekit/skopes/hst/cal/predict.py
+++ b/spacekit/skopes/hst/cal/predict.py
@@ -34,7 +34,7 @@ import argparse
 import numpy as np
 from spacekit.extractor.scrape import S3Scraper
 from spacekit.preprocessor.scrub import CalScrubber
-from spacekit.preprocessor.transform import PowerX
+from spacekit.preprocessor.transform import PowerX, array_to_tensor
 from spacekit.builder.architect import Builder
 from spacekit.logger.log import SPACEKIT_LOG, Logger
 
@@ -120,13 +120,15 @@ class Predict:
 
     def classifier(self, model, data):
         """Returns class prediction"""
-        pred_proba = model.predict(data)
+        X = array_to_tensor(data)
+        pred_proba = model.predict(X)
         pred = int(np.argmax(pred_proba, axis=-1))
         return pred, pred_proba
 
     def regressor(self, model, data):
         """Returns Regression model prediction"""
-        pred = model.predict(data)
+        X = array_to_tensor(data)
+        pred = model.predict(X)
         return pred
 
     def run_inference(self, models={}):
@@ -139,26 +141,6 @@ class Predict:
         self.log.info(f"dataset: {self.dataset} predictions: {self.predictions}")
         self.probabilities = {"dataset": self.dataset, "probabilities": pred_proba}
         self.log.info(self.probabilities)
-
-    def store_results(self):
-        return dict(
-            input_data = self.input_data,
-            inputs = self.inputs,
-            X = self.X,
-            predictions = self.predictions,
-            probabilities = self.probabilities
-        )
-
-    def predict_multiple(self, datasets):
-        preds = {}
-        for dataset in datasets:
-            preds[dataset] = {}
-            self.dataset = dataset
-            self.X = None
-            self.input_data = None
-            self.run_inference()
-            preds[dataset] = self.store_results()
-        return preds
 
 
 def local_handler(dataset, **kwargs):

--- a/spacekit/skopes/hst/cal/train.py
+++ b/spacekit/skopes/hst/cal/train.py
@@ -124,7 +124,11 @@ class Train:
     def load_prep(self):
         df = load(name="calcloud", date_key=self.date_key, fpath=self.fpath)
         self.data = CalPrep(
-            df, "mem_bin", X_cols=self.X_cols, norm_cols=self.norm_cols, rename_cols=self.rename_cols
+            df,
+            "mem_bin",
+            X_cols=self.X_cols,
+            norm_cols=self.norm_cols,
+            rename_cols=self.rename_cols,
         )
         self.data.prep_data()
 

--- a/tests/builder/test_architect.py
+++ b/tests/builder/test_architect.py
@@ -1,5 +1,5 @@
 from pytest import mark
-from spacekit.builder.architect import BuilderEnsemble
+from spacekit.builder.architect import BuilderEnsemble, Builder
 from spacekit.skopes.hst.svm.train import load_ensemble_data
 
 @mark.svm
@@ -50,3 +50,18 @@ def test_ensemble_builder_without_data():
     assert ens.model_path == 'models/ensemble/ensembleSVM'
     ens.find_tx_file()
     assert ens.tx_file == 'models/ensemble/tx_data.json'
+
+
+@mark.cal
+@mark.builder
+@mark.architect
+def test_cal_builder_without_data():
+    builder = Builder(name="mem_clf")
+    builder.load_saved_model("calmodels")
+    assert builder.model is not None
+    assert builder.blueprint == "mem_clf"
+    builder.get_blueprint(builder.blueprint)
+    assert len(builder.model.layers) == 8
+    assert builder.model_path == 'models/calmodels/mem_clf'
+    builder.find_tx_file()
+    assert builder.tx_file == 'models/calmodels/tx_data.json'

--- a/tests/data_plugin.py
+++ b/tests/data_plugin.py
@@ -34,7 +34,7 @@ def pytest_configure(config):
             response = requests.get(data_uri, stream=True)
             if response.status_code == 200:
                 f.write(response.raw.read())
-        chksum = "b670fc7c27d0071855bcca99848ada1d0c0c9ec0f23c20d2ba6460222148fc61"
+        chksum = "d54b319e8535c62858ed3ad5083cf329941c2d1dd1a5e9687c5fe4ccea15f931"
         with open(target_path, "rb") as f:
             digest = hashlib.sha256(f.read())
             if digest.hexdigest() == chksum:

--- a/tests/data_plugin.py
+++ b/tests/data_plugin.py
@@ -27,7 +27,7 @@ def pytest_configure(config):
     data_path = config.getoption("data_path")
     if not os.path.exists(data_path):
         tmp_path_factory = TempPathFactory(config.option.basetemp, trace=config.trace.get("tmpdir"), _ispytest=True)
-        data_uri = "https://zenodo.org/record/7833961/files/pytest_data.tgz?download=1"
+        data_uri = "https://zenodo.org/record/7839172/files/pytest_data.tgz?download=1"
         basepath = tmp_path_factory.getbasetemp()
         target_path = os.path.join(basepath, "pytest_data.tgz")
         with open(target_path, 'wb') as f:

--- a/tests/generator/test_draw.py
+++ b/tests/generator/test_draw.py
@@ -3,6 +3,7 @@ from spacekit.generator.draw import DrawMosaics
 import os
 
 
+@mark.svm
 @mark.generator
 @mark.draw
 def test_draw_from_pattern(single_visit_path, img_outpath, draw_mosaic_pattern):
@@ -16,6 +17,7 @@ def test_draw_from_pattern(single_visit_path, img_outpath, draw_mosaic_pattern):
     assert len(mos.datasets) > 0
 
 
+@mark.svm
 @mark.generator
 @mark.draw
 def test_draw_from_fname(single_visit_path, img_outpath, draw_mosaic_fname):
@@ -29,6 +31,7 @@ def test_draw_from_fname(single_visit_path, img_outpath, draw_mosaic_fname):
     assert len(mos.datasets) > 0
 
 
+@mark.svm
 @mark.generator
 @mark.draw
 def test_draw_from_visit(single_visit_path, img_outpath):
@@ -40,6 +43,7 @@ def test_draw_from_visit(single_visit_path, img_outpath):
     assert mos.datasets[0] == "ibl738"
 
 
+@mark.svm
 @mark.generator
 @mark.draw
 def test_draw_from_priority(single_visit_path, img_outpath, draw_mosaic_fname):
@@ -62,6 +66,7 @@ def test_draw_from_priority(single_visit_path, img_outpath, draw_mosaic_fname):
     assert len(data_from_file) > 0
 
 
+@mark.svm
 @mark.generator
 @mark.draw
 @mark.parametrize("P, S, G", [(0, 0, 0), (1, 1, 0), (0, 0, 1)])
@@ -82,6 +87,7 @@ def test_draw_total_images(single_visit_path, img_outpath, P, S, G):
     assert os.path.exists(img_path)
 
 
+@mark.svm
 @mark.generator
 @mark.draw
 def test_draw_generator(single_visit_path, img_outpath):

--- a/tests/preprocessor/test_encode.py
+++ b/tests/preprocessor/test_encode.py
@@ -167,7 +167,7 @@ def test_pair_encoder_array_2d_unspecified_axis():
 @mark.svm
 @mark.preprocessor
 @mark.encode
-def test_pair_encoder_inverse_transform(scraped_mast_file):
+def test_pair_encoder_inverse_transform():
     data = asarray(["ir", "ir", "uvis", "wfc"], dtype=object)
     detector_keys = {"hrc": 0, "ir": 1, "sbc": 2, "uvis": 3, "wfc": 4}
     enc = PairEncoder()

--- a/tests/preprocessor/test_scrub.py
+++ b/tests/preprocessor/test_scrub.py
@@ -65,14 +65,3 @@ def test_scrub_cols(raw_csv_file, single_visit_path):
             assert True
         else:
             assert False
-
-
-# @mark.preprocessor
-# @mark.scrub
-# def test_alt_svm_scrubber(svm_visit_data):
-#     #data_path = "tests/data/svm/prep/singlevisits/"
-#     scb = SvmScrubber(
-#         svm_visit_data, df=None, output_path="tmp", output_file="scrubbed", crpt=0
-#     )
-#     scb.scrub()
-#     assert os.path.exists(scb.fname)

--- a/tests/preprocessor/test_transform.py
+++ b/tests/preprocessor/test_transform.py
@@ -24,10 +24,10 @@ RENAMED_COLS = {
 @mark.hst
 @mark.preprocessor
 @mark.transform
-def test_transform_arrays_from_file(cfg, df_ncols):
+def test_transform_arrays_from_file(skope, df_ncols):
     (df, ncols) = df_ncols
     X_arr = np.asarray(df)
-    Px = PowerX(X_arr, cols=ncols, tx_file=cfg.tx_file)
+    Px = PowerX(X_arr, cols=ncols, tx_file=skope.tx_file)
     assert list(Px.tx_data.keys()) == ["lambdas", "mu", "sigma"]
     X_norm = Px.Xt
     for i in ncols:
@@ -38,21 +38,21 @@ def test_transform_arrays_from_file(cfg, df_ncols):
 @mark.hst
 @mark.preprocessor
 @mark.transform
-def test_powerx_from_df(cfg, df_ncols):
+def test_powerx_from_df(skope, df_ncols):
     (df, ncols) = df_ncols
     Px = PowerX(
         df,
-        cols=cfg.norm_cols,
+        cols=skope.norm_cols,
         ncols=ncols,
         save_tx=True,
         output_path="tmp",
-        rename=cfg.rename_cols,
+        rename=skope.rename_cols,
         join_data=1,
     )
     assert os.path.exists("tmp/tx_data.json")
     df_norm = Px.Xt
-    assert list(df_norm.columns) == RENAMED_COLS[cfg.env] + cfg.enc_cols
-    for col in RENAMED_COLS[cfg.env]:
+    assert list(df_norm.columns) == RENAMED_COLS[skope.env] + skope.enc_cols
+    for col in RENAMED_COLS[skope.env]:
         assert np.abs(np.round(np.mean(df_norm[col]))) == 0.0
         assert np.abs(np.round(np.std(df_norm[col]))) == 1.0
 
@@ -65,34 +65,34 @@ def test_powerx_from_df(cfg, df_ncols):
 @mark.hst
 @mark.preprocessor
 @mark.transform
-def test_transform_join_options(cfg, df_ncols):
+def test_transform_join_options(skope, df_ncols):
     (df, ncols) = df_ncols
-    Px0 = PowerX(df, cols=cfg.norm_cols, ncols=ncols, rename=None, join_data=0)
+    Px0 = PowerX(df, cols=skope.norm_cols, ncols=ncols, rename=None, join_data=0)
     norm0 = Px0.Xt
-    assert norm0.shape[1] == len(cfg.norm_cols)
-    assert list(norm0.columns) == cfg.norm_cols
+    assert norm0.shape[1] == len(skope.norm_cols)
+    assert list(norm0.columns) == skope.norm_cols
 
-    Px1 = PowerX(df, cols=cfg.norm_cols, ncols=ncols, rename=None, join_data=1)
+    Px1 = PowerX(df, cols=skope.norm_cols, ncols=ncols, rename=None, join_data=1)
     norm1 = Px1.Xt
-    assert norm1.shape[1] == len(cfg.norm_cols + cfg.enc_cols)
+    assert norm1.shape[1] == len(skope.norm_cols + skope.enc_cols)
     assert norm1.shape[1] == len(df.columns)
-    assert list(norm1.columns) == cfg.norm_cols + cfg.enc_cols
+    assert list(norm1.columns) == skope.norm_cols + skope.enc_cols
 
     Px2 = PowerX(
-        df, cols=cfg.norm_cols, ncols=ncols, rename=cfg.rename_cols, join_data=2
+        df, cols=skope.norm_cols, ncols=ncols, rename=skope.rename_cols, join_data=2
     )
     norm2 = Px2.Xt
-    assert norm2.shape[1] == len(df.columns) + len(cfg.norm_cols)
-    assert list(norm2.columns) == RENAMED_COLS[cfg.env] + list(df.columns)
+    assert norm2.shape[1] == len(df.columns) + len(skope.norm_cols)
+    assert list(norm2.columns) == RENAMED_COLS[skope.env] + list(df.columns)
 
 
 @mark.hst
 @mark.preprocessor
 @mark.transform
-def test_transform_1d_series(cfg, df_ncols):
+def test_transform_1d_series(skope, df_ncols):
     (df, _) = df_ncols
     x = df.iloc[0]
-    x_norm = PowerX(x, cols=cfg.norm_cols, tx_file=cfg.tx_file).Xt
+    x_norm = PowerX(x, cols=skope.norm_cols, tx_file=skope.tx_file).Xt
     assert len(x_norm.shape) == 2
     assert x_norm.shape[0] == 1
 
@@ -100,10 +100,10 @@ def test_transform_1d_series(cfg, df_ncols):
 @mark.hst
 @mark.preprocessor
 @mark.transform
-def test_transform_1d_array(cfg, df_ncols):
+def test_transform_1d_array(skope, df_ncols):
     (df, ncols) = df_ncols
     x = np.asarray(df.iloc[0])
-    x_norm = PowerX(x, cols=ncols, tx_file=cfg.tx_file).Xt
+    x_norm = PowerX(x, cols=ncols, tx_file=skope.tx_file).Xt
     assert len(x_norm.shape) == 2
     assert x_norm.shape[0] == 1
 

--- a/tests/skopes/hst/cal/test_cal_predict.py
+++ b/tests/skopes/hst/cal/test_cal_predict.py
@@ -1,0 +1,69 @@
+import os
+from pytest import mark
+from moto import mock_s3
+from spacekit.skopes.hst.cal.predict import Predict, local_handler, lambda_handler
+import boto3
+
+
+EXPECTED_PREDS = {
+    "asn": {
+        "j8zs05020": {'memBin': 3, 'memVal': 18.89, 'clockTime': 76479},
+        "ic0k06010": {'memBin': 2, 'memVal': 8.55, 'clockTime': 13904},
+        "la8mffg5q": {'memBin': 0, 'memVal': 0.8, 'clockTime': 295},
+        "oc3p011i0": {'memBin': 0, 'memVal': 0.47, 'clockTime': 55}
+    }
+}
+
+
+def put_moto_s3_object(dataset, bucketname):
+    client = boto3.client("s3", region_name="us-east-1")
+    fpath = f"tests/data/cal/predict/{dataset}_MemModelFeatures.txt"
+    obj = f"control/{dataset}/{dataset}_MemModelFeatures.txt"
+    with open(f"{fpath}", "rb") as f:
+        client.upload_fileobj(f, bucketname, obj)
+
+
+@mark.parameterize("pipeline", [("asn")])
+@mock_s3
+def test_local_predict_handler(cal_predict_visits, pipeline):
+    bucketname = "spacekit_bucket"
+    s3 = boto3.resource("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=bucketname)
+    dataset = cal_predict_visits(pipeline)[0] # ["j8zs05020", "ic0k06010", "la8mffg5q", "oc3p011i0"]
+    put_moto_s3_object(dataset, bucketname)
+    pred = local_handler(dataset, bucket_name=bucketname)
+    for k, v in pred.predictions.items():
+        assert v == EXPECTED_PREDS[pipeline][dataset][k]
+
+
+@mark.parameterize("pipeline", [("asn")])
+@mock_s3
+def test_predict_multiple(cal_predict_visits, pipeline):
+    bucketname = "spacekit_bucket"
+    s3 = boto3.resource("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=bucketname)
+    datasets = cal_predict_visits(pipeline) # ["j8zs05020", "ic0k06010", "la8mffg5q", "oc3p011i0"]
+    for d in datasets:
+        put_moto_s3_object(d, bucketname)
+    predictor = Predict(datasets[0], bucket_name=bucketname)
+    preds = predictor.predict_multiple(datasets)
+    for dataset, vals in preds.items():
+        expected = EXPECTED_PREDS[pipeline][dataset]
+        for k, v in vals['predictions'].items():
+            assert v == expected[k]
+
+
+@mark.parameterize("pipeline", [("asn")])
+@mock_s3
+def test_lambda_handler(cal_predict_visits, pipeline):
+    bucketname = "spacekit_bucket"
+    s3 = boto3.resource("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=bucketname)
+    dataset = cal_predict_visits(pipeline)[0] # ["j8zs05020", "ic0k06010", "la8mffg5q", "oc3p011i0"]
+    put_moto_s3_object(dataset, bucketname)
+    os.environ["MODEL_PATH"] = "models/calmodels"
+    key = f"control/{dataset}/{dataset}_MemModelFeatures.txt"
+    event = dict(Dataset=dataset, Bucket=bucketname, Key=key)
+    preds = lambda_handler(event, None)
+    for k, v in preds.items():
+        assert v == EXPECTED_PREDS[pipeline][dataset][k]

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,9 @@ markers =
     builder
 
 [testenv:dev]
-deps = pytest-astropy
+deps = 
+    pytest-astropy
+    moto
 commands =
     pytest
     #pytest-datafiles


### PR DESCRIPTION
Pytest configuration updates:
- allow pytest to run multi skope envs if env flag not set
- add moto to test deps
- Added hst cal predict tests using moto for mock s3 testing
- updated DOI for pytestdata modifications
- remove test/data from source
- replace "cfg" with "skope" in conftest to match source code naming convention
- infer blueprint from name attribute if arch="calmodels" when loading pretrained NN