### PR TITLE
compute/use-npz-instead-of-pickle

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -112,18 +112,22 @@ def pytest_addoption(parser):
     parser.addoption("--env", action="store", default=None, help="Environment to run tests against")
 
 # def pytest_configure(config):
-#     config.addinivalue_line("markers", "skopes: check env against param")
+#     config.addinivalue_line("markers", "skope_svm: only run in svm skope")
+#     config.addinivalue_line("markers", "skope_cal: only run in cal skope")
 
-# def pytest_collection_modifyitems(config, items):
-#     env_param = config.getoption("--env")
-#     if env_param:
-#         skope_param = pytest.mark.parametrize("skope", [(env_param)], indirect=True)
-#     else:
-#         skope_param = pytest.mark.parametrize("skope", [("cal", "svm")], indirect=True)
-#         # skip_param = pytest.mark.skipif(reason="skip params based on --env")
-#     for item in items:
-#         if "skopes" in item.keywords:
-#             item.add_marker(skope_param)
+# def pytest_collection_modifyitems(config, items, skope):
+#     if skope.env == "cal"
+    # env_param = config.getoption("--env")
+    # if env_param:
+    #     skope_param = pytest.mark.parametrize("skope", [(env_param)], indirect=True)
+    # else:
+    #     skope_param = pytest.mark.parametrize("skope", [("cal", "svm")], indirect=True)
+    #     # skip_param = pytest.mark.skipif(reason="skip params based on --env")
+    # for item in items:
+    #     if "skopes" in item.keywords:
+    #         item.add_marker(skope_param)
+
+
 
 
 @fixture(scope="session")
@@ -138,6 +142,12 @@ def skope(request):
         pytest.skip(reason="skipping param based on --env")
     else:
         return Config(request.param)
+
+
+def check_skope(skope, param):
+    if skope.env != param:
+        pytest.skip(reason="skipping based on skope param")
+
 
 @fixture(scope="session")
 def test_data(request):
@@ -211,9 +221,9 @@ def img_outpath(tmp_path):
 
 
 # # SVM PREDICT
-@fixture(scope="function")
-def svm_unlabeled_dataset():
-    return "tests/data/svm/predict/unlabeled.csv"
+# @fixture(scope="function")
+# def svm_unlabeled_dataset():
+#     return "tests/data/svm/predict/unlabeled.csv"
 
 
 @fixture(scope="session", params=["img.tgz", "img_pred.npz"])
@@ -228,9 +238,9 @@ def svm_pred_img(request, tmp_path_factory):
 
 
 # # SVM TRAIN
-@fixture(scope="function")  # session
-def svm_labeled_dataset():
-    return "tests/data/svm/train/training.csv"
+# @fixture(scope="function")  # session
+# def svm_labeled_dataset():
+#     return "tests/data/svm/train/training.csv"
 
 
 @fixture(scope="session", params=["img.tgz", "img_data.npz"])
@@ -305,9 +315,9 @@ def scraped_mast_file():
 
 
 # CAL
-@fixture(scope="function")
-def cal_labeled_dataset():
-    return "tests/data/cal/train/training.csv"
+# @fixture(scope="function")
+# def cal_labeled_dataset():
+#     return "tests/data/cal/train/training.csv"
 
 # @fixture(scope="function")
 # def training_data_file(skope):

--- a/conftest.py
+++ b/conftest.py
@@ -128,8 +128,6 @@ def pytest_addoption(parser):
     #         item.add_marker(skope_param)
 
 
-
-
 @fixture(scope="session")
 def env(request):
     return request.config.getoption("--env")

--- a/conftest.py
+++ b/conftest.py
@@ -130,10 +130,6 @@ def pytest_addoption(parser):
 def env(request):
     return request.config.getoption("--env")
 
-# @fixture(scope="session")
-# def cfg(env):
-#     cfg = Config(env)
-#     return cfg
 
 @fixture(scope="session", params=["cal", "svm"])
 def skope(request):
@@ -154,7 +150,7 @@ def res_data_path(test_data, skope):
     if not os.path.exists(skope_data):
         with ZipFile(skope.data_path, "r") as z:
             z.extractall(os.path.dirname(skope_data))
-    return skope_data 
+    return skope_data
 
 
 @fixture(scope="session")
@@ -187,6 +183,16 @@ def explorer(skope, res_data_path):
     hst.env = skope.env
     return hst
 
+@fixture(scope="session")
+def labeled_dataset(skope):
+    return skope.labeled
+    # return "tests/data/svm/train/training.csv"
+
+
+@fixture(scope="session")  # session
+def unlabeled_dataset(skope):
+    return skope.unlabeled
+
 
 # SVM PREP
 @fixture(scope="session")  # "ibl738.tgz"
@@ -204,7 +210,7 @@ def img_outpath(tmp_path):
     return os.path.join(tmp_path, "img")
 
 
-# SVM PREDICT
+# # SVM PREDICT
 @fixture(scope="function")
 def svm_unlabeled_dataset():
     return "tests/data/svm/predict/unlabeled.csv"
@@ -221,7 +227,7 @@ def svm_pred_img(request, tmp_path_factory):
     return img_path
 
 
-# SVM TRAIN
+# # SVM TRAIN
 @fixture(scope="function")  # session
 def svm_labeled_dataset():
     return "tests/data/svm/train/training.csv"

--- a/docs/source/extractor/load.rst
+++ b/docs/source/extractor/load.rst
@@ -24,3 +24,25 @@ spacekit.extractor.load
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. autofunction:: save_dct_to_txt
+
+.. autofunction:: save_dict
+
+.. autofunction:: save_json
+
+.. autofunction:: save_dataframe
+
+.. autofunction:: save_dataframe
+
+.. autofunction:: zip_subdirs
+
+.. autofunction:: is_within_directory
+
+.. autofunction:: safe_extract
+
+.. autofunction:: extract_file
+
+.. autofunction:: save_multitype_data
+
+.. autofunction:: load_multitype_data

--- a/spacekit/analyzer/compute.py
+++ b/spacekit/analyzer/compute.py
@@ -1,6 +1,5 @@
 import os
 import glob
-import pickle
 import itertools
 import numpy as np
 import pandas as pd
@@ -15,20 +14,19 @@ from sklearn.metrics import (
 )
 from tensorflow.python.ops.numpy_ops import np_config
 from spacekit.logger.log import Logger
-
+from spacekit.extractor.load import save_multitype_data, load_multitype_data
 try:
     import plotly.graph_objects as go
     import matplotlib as mpl
     import matplotlib.pyplot as plt
+    plt.style.use("seaborn-bright")
+    font_dict = {"family": "monospace", "size": 16}  # Titillium Web
+    mpl.rc("font", **font_dict)
 except ImportError:
     go = None
     mpl = None
     plt = None
 
-
-plt.style.use("seaborn-bright")
-font_dict = {"family": "monospace", "size": 16}  # Titillium Web
-mpl.rc("font", **font_dict)
 
 
 def check_viz_imports():
@@ -168,11 +166,14 @@ class Computer(object):
             datestamp = dt.date.fromtimestamp(timestamp).isoformat()
             prefix = str(datestamp) + "-" + str(timestamp)
             self.res_path = os.path.join(os.getcwd(), prefix, "results", self.algorithm)
-        os.makedirs(f"{self.res_path}", exist_ok=True)
-        for k, v in outputs.items():
-            key = f"{self.res_path}/{k}"
-            with open(key, "wb") as pyfi:
-                pickle.dump(v, pyfi)
+        save_multitype_data(
+            outputs,
+            f"{self.res_path}",
+            fnfp='nested',
+            acc_loss='arrays',
+            history='arrays',
+            loss='arrays'
+        )
         self.log.info(f"Results saved to: {self.res_path}")
 
     def upload(self):
@@ -191,16 +192,7 @@ class Computer(object):
                 self.log.error(f"No results found @ {self.res_path} \n", e)
                 return outputs
         if os.path.exists(self.res_path):
-            try:
-                for r in glob.glob(f"{self.res_path}/*"):
-                    key = r.split("/")[-1]
-                    with open(r, "rb") as pyfi:
-                        outputs[key] = pickle.load(pyfi)
-            except ModuleNotFoundError:
-                self.log.error(
-                    "Results were saved in an older version of Pandas "
-                    " (<2.x). Downgrade to Pandas 1.x and try again."
-                )
+            outputs = load_multitype_data(self.res_path)
         else:
             self.log.error(f"Path DNE @ {self.res_path}")
         return outputs

--- a/spacekit/analyzer/compute.py
+++ b/spacekit/analyzer/compute.py
@@ -15,10 +15,12 @@ from sklearn.metrics import (
 from tensorflow.python.ops.numpy_ops import np_config
 from spacekit.logger.log import Logger
 from spacekit.extractor.load import save_multitype_data, load_multitype_data
+
 try:
     import plotly.graph_objects as go
     import matplotlib as mpl
     import matplotlib.pyplot as plt
+
     plt.style.use("seaborn-bright")
     font_dict = {"family": "monospace", "size": 16}  # Titillium Web
     mpl.rc("font", **font_dict)
@@ -26,7 +28,6 @@ except ImportError:
     go = None
     mpl = None
     plt = None
-
 
 
 def check_viz_imports():
@@ -169,10 +170,10 @@ class Computer(object):
         save_multitype_data(
             outputs,
             f"{self.res_path}",
-            fnfp='nested',
-            acc_loss='arrays',
-            history='arrays',
-            loss='arrays'
+            fnfp="nested",
+            acc_loss="arrays",
+            history="arrays",
+            loss="arrays",
         )
         self.log.info(f"Results saved to: {self.res_path}")
 

--- a/spacekit/analyzer/explore.py
+++ b/spacekit/analyzer/explore.py
@@ -15,6 +15,7 @@ except ImportError:
 try:
     import matplotlib as mpl
     import matplotlib.pyplot as plt
+
     plt.style.use("seaborn-bright")
     font_dict = {"family": "monospace", "size": 16}
     mpl.rc("font", **font_dict)
@@ -56,6 +57,7 @@ class ImagePreviews:
                 "for the compute module to work."
                 "\n\nInstall extra deps via `pip install spacekit[x]`"
             )
+
 
 class SVMPreviews(ImagePreviews):
     """ImagePreviews subclass for previewing SVM images. Primarily can be used to compare original with augmented versions.
@@ -470,7 +472,6 @@ class DataPlots:
         height=500,
         cmap=["dodgerblue", "fuchsia"],
     ):
-
         traces = []
         for i in self.classes:
             i = int(i)

--- a/spacekit/datasets/meta.py
+++ b/spacekit/datasets/meta.py
@@ -1,30 +1,30 @@
 calcloud = {
-    "uri": "https://zenodo.org/record/7839172/files",
+    "uri": "https://zenodo.org/record/8180727/files",
     "data": {
         "2022-02-14": {
             "fname": "hst_cal_std_2022-02-14.zip?download=1",
-            "hash": "7522ec6bdaffaa06827e9ec9781b5182",
+            "hash": "1f59a81785809c8ca817f44376aba824",
             "desc": "data, model and training results",
             "key": "2022-02-14-1644848448",
-            "size": "12.9MB",
+            "size": "10.8MB",
         },
         "2021-11-04": {
             "fname": "hst_cal_std_2021-11-04.zip?download=1",
-            "hash": "d1ba4329ee18219e1a562d7a72c96368",
+            "hash": "158ec68fbaeace4e8599262999d9772e",
             "desc": "data, model and training results",
             "key": "2021-11-04-1636048291",
-            "size": "11.6MB",
+            "size": "11.5MB",
         },
         "2021-10-28": {
             "fname": "hst_cal_std_2021-10-28.zip?download=1",
-            "hash": "09fe043a61165def660ca0209a4c562e",
+            "hash": "2addecfe13d22f8b552b3b907705d688",
             "desc": "data, model and training results",
             "key": "2021-10-28-1635457222",
             "size": "8.6MB",
         },
         "2021-08-22": {
             "fname": "hst_cal_std_2021-08-22.zip?download=1",
-            "hash": "2ac4857954ddcd384c43a9a0dd8d7cff",
+            "hash": "c8ab3427fb5f0819d905901167061030",
             "desc": "data, model and training results",
             "key": "2021-08-22-1629663047",
             "size": "6MB",
@@ -40,28 +40,28 @@ calcloud = {
 }
 
 svm = {
-    "uri": "https://zenodo.org/record/7839172/files",
+    "uri": "https://zenodo.org/record/8180727/files",
     "data": {
         "2022-02-14": {
             "fname": "hst_drz_svm_2022-02-14.zip?download=1",
-            "hash": "c0590ee3277aa1f2607a0d9ad827db27",
+            "hash": "6a43e41e5a21be6bf8af1305753b6c54",
             "desc": "latest model, data and training results",
             "key": "2022-02-14-1644850390",
             "size": "18MB",
         },
         "2022-01-30": {
             "fname": "hst_drz_svm_2022-01-30.zip?download=1",
-            "hash": "758334cf0f4e80038e2f966ac5c044a1",
-            "desc": "retrained model, data and training results",
+            "hash": "761471ebbbce908d268a757abc72238e",
+            "desc": "retrained model training results",
             "key": "2022-01-30-1643523529",
             "size": "18MB",
         },
         "2022-01-16": {
             "fname": "hst_drz_svm_2022-01-16.zip?download=1",
-            "hash": "8c0e87943afeb62404df0d2e529051d6",
-            "desc": "baseline model, data and training results",
+            "hash": "d6273a59116cf1359e761e5822b59d61",
+            "desc": "baseline model training results",
             "key": "2022-01-16-1642337739",
-            "size": "34.1kB",
+            "size": "20.8kB",
         },
         "2021-07-28": {
             "fname": "svm_labeled_2021-07-28.csv?download=1",
@@ -88,7 +88,7 @@ svm = {
 }
 
 k2 = {
-    "uri": "https://zenodo.org/record/7839172/files",
+    "uri": "https://zenodo.org/record/8180727/files",
     "data": {
         "test": {
             "fname": "k2-exo-flux-ts-test.csv.zip?download=1",

--- a/spacekit/datasets/meta.py
+++ b/spacekit/datasets/meta.py
@@ -1,33 +1,33 @@
 calcloud = {
-    "uri": "https://zenodo.org/record/8180727/files",
+    "uri": "https://zenodo.org/record/8185020/files",
     "data": {
         "2022-02-14": {
             "fname": "hst_cal_std_2022-02-14.zip?download=1",
-            "hash": "1f59a81785809c8ca817f44376aba824",
+            "hash": "e9375c65feb413a660cb737a9a8a3a73",
             "desc": "data, model and training results",
             "key": "2022-02-14-1644848448",
-            "size": "10.8MB",
+            "size": "11.4MB",
         },
         "2021-11-04": {
             "fname": "hst_cal_std_2021-11-04.zip?download=1",
-            "hash": "158ec68fbaeace4e8599262999d9772e",
+            "hash": "029fcba4e4f576faf259035b2c20d13c",
             "desc": "data, model and training results",
             "key": "2021-11-04-1636048291",
-            "size": "11.5MB",
+            "size": "11.4MB",
         },
         "2021-10-28": {
             "fname": "hst_cal_std_2021-10-28.zip?download=1",
-            "hash": "2addecfe13d22f8b552b3b907705d688",
+            "hash": "2dc85c941627c8aec7bac0ebe725d7dd",
             "desc": "data, model and training results",
             "key": "2021-10-28-1635457222",
-            "size": "8.6MB",
+            "size": "8.5MB",
         },
         "2021-08-22": {
             "fname": "hst_cal_std_2021-08-22.zip?download=1",
-            "hash": "c8ab3427fb5f0819d905901167061030",
+            "hash": "6a422aa2913194ff2af03398ca2403be",
             "desc": "data, model and training results",
             "key": "2021-08-22-1629663047",
-            "size": "6MB",
+            "size": "5.9MB",
         },
     },
     "model": {
@@ -40,28 +40,28 @@ calcloud = {
 }
 
 svm = {
-    "uri": "https://zenodo.org/record/8180727/files",
+    "uri": "https://zenodo.org/record/8185020/files",
     "data": {
         "2022-02-14": {
             "fname": "hst_drz_svm_2022-02-14.zip?download=1",
-            "hash": "6a43e41e5a21be6bf8af1305753b6c54",
+            "hash": "3d6ade5510cc7aad4c2c45329c0751fe",
             "desc": "latest model, data and training results",
             "key": "2022-02-14-1644850390",
             "size": "18MB",
         },
         "2022-01-30": {
             "fname": "hst_drz_svm_2022-01-30.zip?download=1",
-            "hash": "761471ebbbce908d268a757abc72238e",
-            "desc": "retrained model training results",
+            "hash": "9ad9b95c20b82877f1ea7b0fa64b10a1",
+            "desc": "updated model, data and training results",
             "key": "2022-01-30-1643523529",
             "size": "18MB",
         },
         "2022-01-16": {
             "fname": "hst_drz_svm_2022-01-16.zip?download=1",
-            "hash": "d6273a59116cf1359e761e5822b59d61",
+            "hash": "7a5f99b1448ba09e7323f48fd7899ae5",
             "desc": "baseline model training results",
             "key": "2022-01-16-1642337739",
-            "size": "20.8kB",
+            "size": "24.8kB",
         },
         "2021-07-28": {
             "fname": "svm_labeled_2021-07-28.csv?download=1",
@@ -88,7 +88,7 @@ svm = {
 }
 
 k2 = {
-    "uri": "https://zenodo.org/record/8180727/files",
+    "uri": "https://zenodo.org/record/8185020/files",
     "data": {
         "test": {
             "fname": "k2-exo-flux-ts-test.csv.zip?download=1",

--- a/spacekit/extractor/load.py
+++ b/spacekit/extractor/load.py
@@ -677,13 +677,13 @@ def save_multitype_data(data_dict, output_path, **npz_kwargs):
         else:
             npzd = npz_kwargs.get(k, None)
             npzpath = f"{output_path}/{k}.npz"
-            nest_arr = {k:dict()}
+            nest_arr = {k: dict()}
             nested_data = False
-            if npzd == 'arrays':
+            if npzd == "arrays":
                 for i, j in v.items():
                     j = np.asarray(j)
                 np.savez(npzpath, **v)
-            elif npzd == 'nested':
+            elif npzd == "nested":
                 for i, j in v.items():
                     if isinstance(j, dict):
                         nested_data = True
@@ -697,7 +697,7 @@ def save_multitype_data(data_dict, output_path, **npz_kwargs):
                 save_json(v, f"{output_path}/{k}.json")
 
 
-def load_multitype_data(input_path, index_names=['index','ipst']):
+def load_multitype_data(input_path, index_names=["index", "ipst"]):
     outputs = dict()
     files = glob.glob(f"{input_path}/*")
     for f in files:
@@ -722,7 +722,7 @@ def load_multitype_data(input_path, index_names=['index','ipst']):
         elif sfx == "npz":
             subkey = None
             if nested_keys:
-                key,subkey = nested_keys
+                key, subkey = nested_keys
             if key not in outputs:
                 outputs[key] = dict()
             if subkey:
@@ -753,8 +753,15 @@ def load_multitype_data(input_path, index_names=['index','ipst']):
     return outputs
 
 
-def overwrite_results(input_path, out=None, subdirs=["memory", "wallclock","mem_bin"], delete_existing=False, **npz_kwargs):
+def overwrite_results(
+    input_path,
+    out=None,
+    subdirs=["memory", "wallclock", "mem_bin"],
+    delete_existing=False,
+    **npz_kwargs,
+):
     import shutil
+
     for sub in subdirs:
         respath = os.path.join(input_path, sub)
         outputs = load_multitype_data(respath)

--- a/spacekit/generator/draw.py
+++ b/spacekit/generator/draw.py
@@ -25,6 +25,7 @@ except ImportError:
 def check_viz_imports():
     return plt is not None
 
+
 def check_imports():
     if not check_viz_imports():
         return False

--- a/spacekit/logger/log.py
+++ b/spacekit/logger/log.py
@@ -21,7 +21,6 @@ import logging
 
 # Logging formatter supporting colorized output
 class LogFormatter(logging.Formatter):
-
     COLOR_CODES = {
         logging.CRITICAL: "\033[1;35m",  # bright/bold magenta
         logging.ERROR: "\033[1;31m",  # bright/bold red

--- a/spacekit/skopes/hst/cal/validate.py
+++ b/spacekit/skopes/hst/cal/validate.py
@@ -14,7 +14,6 @@ from spacekit.extractor.load import save_to_pickle
 
 
 def k_estimator(buildClass, n_splits=10, y=None, stratify=False):
-
     bld = buildClass()
 
     if stratify is True:

--- a/tests/builder/test_architect.py
+++ b/tests/builder/test_architect.py
@@ -1,13 +1,15 @@
 from pytest import mark
+from conftest import check_skope
 from spacekit.builder.architect import BuilderEnsemble, Builder
 from spacekit.skopes.hst.svm.train import load_ensemble_data
 
 @mark.svm
 @mark.builder
 @mark.architect
-def test_ensemble_builder_with_data(svm_labeled_dataset, svm_train_npz):
+def test_ensemble_builder_with_data(skope, labeled_dataset, svm_train_npz):
+    check_skope(skope, "svm")
     tv_idx, XTR, YTR, XTS, YTS, _, _ = load_ensemble_data(
-        svm_labeled_dataset,
+        labeled_dataset,
         svm_train_npz,
         img_size=128,
         norm=0,
@@ -40,7 +42,8 @@ def test_ensemble_builder_with_data(svm_labeled_dataset, svm_train_npz):
 @mark.svm
 @mark.builder
 @mark.architect
-def test_ensemble_builder_without_data():
+def test_ensemble_builder_without_data(skope):
+    check_skope(skope, "svm")
     ens = BuilderEnsemble()
     assert ens.blueprint == "ensemble"
     assert ens.steps_per_epoch > 0
@@ -55,7 +58,8 @@ def test_ensemble_builder_without_data():
 @mark.cal
 @mark.builder
 @mark.architect
-def test_cal_builder_without_data():
+def test_cal_builder_without_data(skope):
+    check_skope(skope, "cal")
     builder = Builder(name="mem_clf")
     builder.load_saved_model("calmodels")
     assert builder.model is not None

--- a/tests/builder/test_architect.py
+++ b/tests/builder/test_architect.py
@@ -3,6 +3,7 @@ from conftest import check_skope
 from spacekit.builder.architect import BuilderEnsemble, Builder
 from spacekit.skopes.hst.svm.train import load_ensemble_data
 
+
 @mark.svm
 @mark.builder
 @mark.architect
@@ -39,6 +40,7 @@ def test_ensemble_builder_with_data(skope, labeled_dataset, svm_train_npz):
     ens.build()
     assert ens.model is not None
 
+
 @mark.svm
 @mark.builder
 @mark.architect
@@ -50,9 +52,9 @@ def test_ensemble_builder_without_data(skope):
     ens.load_saved_model(arch="ensemble")
     assert ens.model is not None
     assert len(ens.model.layers) == 28
-    assert ens.model_path == 'models/ensemble/ensembleSVM'
+    assert ens.model_path == "models/ensemble/ensembleSVM"
     ens.find_tx_file()
-    assert ens.tx_file == 'models/ensemble/tx_data.json'
+    assert ens.tx_file == "models/ensemble/tx_data.json"
 
 
 @mark.cal
@@ -66,6 +68,6 @@ def test_cal_builder_without_data(skope):
     assert builder.blueprint == "mem_clf"
     builder.get_blueprint(builder.blueprint)
     assert len(builder.model.layers) == 8
-    assert builder.model_path == 'models/calmodels/mem_clf'
+    assert builder.model_path == "models/calmodels/mem_clf"
     builder.find_tx_file()
-    assert builder.tx_file == 'models/calmodels/tx_data.json'
+    assert builder.tx_file == "models/calmodels/tx_data.json"

--- a/tests/data_plugin.py
+++ b/tests/data_plugin.py
@@ -5,20 +5,21 @@ import os
 import shutil
 from pytest import TempPathFactory
 
+
 def pytest_addoption(parser):
     parser.addoption(
         "--data_path",
         action="store",
         dest="data_path",
         default=os.path.abspath("tests/data"),
-        help="Default pytest data path"
+        help="Default pytest data path",
     )
     parser.addoption(
         "--cleanup",
         action="store_true",
         dest="cleanup",
         default=False,
-        help="Remove test data saved in tests/data"
+        help="Remove test data saved in tests/data",
     )
 
 
@@ -27,12 +28,14 @@ def pytest_configure(config):
     data_path = config.getoption("data_path")
     # only retrieve from zenodo if tests/data/{env}/data.zip DNE
     if not os.path.exists(data_path):
-        #tmp_path_factory = TempPathFactory(config.option.basetemp, retention_count, retention_policy, trace=config.trace.get("tmpdir"), _ispytest=True)
-        tmp_path_factory = TempPathFactory(config.option.basetemp, trace=config.trace.get("tmpdir"), _ispytest=True)
+        # tmp_path_factory = TempPathFactory(config.option.basetemp, retention_count, retention_policy, trace=config.trace.get("tmpdir"), _ispytest=True)
+        tmp_path_factory = TempPathFactory(
+            config.option.basetemp, trace=config.trace.get("tmpdir"), _ispytest=True
+        )
         data_uri = "https://zenodo.org/record/8185020/files/pytest_data.tgz?download=1"
         basepath = tmp_path_factory.getbasetemp()
         target_path = os.path.join(basepath, "pytest_data.tgz")
-        with open(target_path, 'wb') as f:
+        with open(target_path, "wb") as f:
             response = requests.get(data_uri, stream=True)
             if response.status_code == 200:
                 f.write(response.raw.read())
@@ -42,6 +45,7 @@ def pytest_configure(config):
             if digest.hexdigest() == chksum:
                 with tarfile.TarFile.open(target_path) as tar:
                     tar.extractall(os.path.abspath("tests"))
+
 
 def pytest_unconfigure(config):
     cleanup = config.getoption("cleanup")

--- a/tests/data_plugin.py
+++ b/tests/data_plugin.py
@@ -28,14 +28,14 @@ def pytest_configure(config):
     if not os.path.exists(data_path):
         #tmp_path_factory = TempPathFactory(config.option.basetemp, retention_count, retention_policy, trace=config.trace.get("tmpdir"), _ispytest=True)
         tmp_path_factory = TempPathFactory(config.option.basetemp, trace=config.trace.get("tmpdir"), _ispytest=True)
-        data_uri = "https://zenodo.org/record/7839172/files/pytest_data.tgz?download=1"
+        data_uri = "https://zenodo.org/record/8180727/files/pytest_data.tgz?download=1"
         basepath = tmp_path_factory.getbasetemp()
         target_path = os.path.join(basepath, "pytest_data.tgz")
         with open(target_path, 'wb') as f:
             response = requests.get(data_uri, stream=True)
             if response.status_code == 200:
                 f.write(response.raw.read())
-        chksum = "d54b319e8535c62858ed3ad5083cf329941c2d1dd1a5e9687c5fe4ccea15f931"
+        chksum = "154c814e66fe9f4e5b8c6ed0f803590a5311024f12ad8fce8de94798212c68da"
         with open(target_path, "rb") as f:
             digest = hashlib.sha256(f.read())
             if digest.hexdigest() == chksum:

--- a/tests/data_plugin.py
+++ b/tests/data_plugin.py
@@ -25,17 +25,18 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.option.disable_warnings = True
     data_path = config.getoption("data_path")
+    # only retrieve from zenodo if tests/data/{env}/data.zip DNE
     if not os.path.exists(data_path):
         #tmp_path_factory = TempPathFactory(config.option.basetemp, retention_count, retention_policy, trace=config.trace.get("tmpdir"), _ispytest=True)
         tmp_path_factory = TempPathFactory(config.option.basetemp, trace=config.trace.get("tmpdir"), _ispytest=True)
-        data_uri = "https://zenodo.org/record/8180727/files/pytest_data.tgz?download=1"
+        data_uri = "https://zenodo.org/record/8185020/files/pytest_data.tgz?download=1"
         basepath = tmp_path_factory.getbasetemp()
         target_path = os.path.join(basepath, "pytest_data.tgz")
         with open(target_path, 'wb') as f:
             response = requests.get(data_uri, stream=True)
             if response.status_code == 200:
                 f.write(response.raw.read())
-        chksum = "154c814e66fe9f4e5b8c6ed0f803590a5311024f12ad8fce8de94798212c68da"
+        chksum = "1a5204f3a5f5c42173e1da389a420ab2d079ecbd27323d50b5fc4155da643399"
         with open(target_path, "rb") as f:
             digest = hashlib.sha256(f.read())
             if digest.hexdigest() == chksum:

--- a/tests/extractor/test_radio.py
+++ b/tests/extractor/test_radio.py
@@ -1,6 +1,7 @@
 from pytest import mark
 from spacekit.extractor.radio import HstSvmRadio
 
+
 @mark.hst
 @mark.svm
 @mark.extractor

--- a/tests/preprocessor/test_scrub.py
+++ b/tests/preprocessor/test_scrub.py
@@ -28,13 +28,18 @@ FINAL_COLS = [
     "cat",
 ]
 
+
 @mark.hst
 @mark.svm
 @mark.preprocessor
 @mark.scrub
 def test_svm_scrubber(raw_svm_data, single_visit_path):
     scrubber = HstSvmScrubber(
-        single_visit_path, data=raw_svm_data, output_path="tmp", output_file="scrubbed", crpt=0
+        single_visit_path,
+        data=raw_svm_data,
+        output_path="tmp",
+        output_file="scrubbed",
+        crpt=0,
     )
     assert scrubber.df.shape[1] == 9
     scrubber.preprocess_data()
@@ -54,7 +59,11 @@ def test_svm_scrubber(raw_svm_data, single_visit_path):
 @mark.scrub
 def test_scrub_cols(raw_svm_data, single_visit_path):
     scrubber = HstSvmScrubber(
-        single_visit_path, data=raw_svm_data, output_path="tmp", output_file="scrubbed", crpt=0
+        single_visit_path,
+        data=raw_svm_data,
+        output_path="tmp",
+        output_file="scrubbed",
+        crpt=0,
     )
     scrubber.scrub_columns()
     assert scrubber.df.shape == (1, 10)

--- a/tests/preprocessor/test_transform.py
+++ b/tests/preprocessor/test_transform.py
@@ -1,4 +1,5 @@
 from pytest import mark
+from conftest import check_skope
 from spacekit.extractor.load import load_datasets, SVMImageIO
 from spacekit.preprocessor.transform import PowerX
 import numpy as np
@@ -111,8 +112,9 @@ def test_transform_1d_array(skope, df_ncols):
 @mark.svm
 @mark.preprocessor
 @mark.transform
-def test_svm_normalize_training(svm_labeled_dataset, svm_train_npz):
-    df = load_datasets([svm_labeled_dataset])
+def test_svm_normalize_training(skope, labeled_dataset, svm_train_npz):
+    check_skope(skope, "svm")
+    df = load_datasets([labeled_dataset])
     (X, _), _ = SVMImageIO(
         svm_train_npz, w=128, h=128, d=3 * 3, inference=False, data=df, v=0.85
     ).load()

--- a/tests/skopes/hst/cal/test_cal_predict.py
+++ b/tests/skopes/hst/cal/test_cal_predict.py
@@ -7,10 +7,10 @@ import boto3
 
 EXPECTED_PREDS = {
     "asn": {
-        "j8zs05020": {'memBin': 3, 'memVal': 18.89, 'clockTime': 76479},
-        "ic0k06010": {'memBin': 2, 'memVal': 8.55, 'clockTime': 13904},
-        "la8mffg5q": {'memBin': 0, 'memVal': 0.8, 'clockTime': 295},
-        "oc3p011i0": {'memBin': 0, 'memVal': 0.47, 'clockTime': 55}
+        "j8zs05020": {"memBin": 3, "memVal": 18.89, "clockTime": 76479},
+        "ic0k06010": {"memBin": 2, "memVal": 8.55, "clockTime": 13904},
+        "la8mffg5q": {"memBin": 0, "memVal": 0.8, "clockTime": 295},
+        "oc3p011i0": {"memBin": 0, "memVal": 0.47, "clockTime": 55},
     }
 }
 
@@ -32,7 +32,7 @@ def test_local_predict_handler(cal_predict_visits, pipeline):
     bucketname = "spacekit_bucket"
     s3 = boto3.resource("s3", region_name="us-east-1")
     s3.create_bucket(Bucket=bucketname)
-    dataset = cal_predict_visits[pipeline][0] # "j8zs05020"
+    dataset = cal_predict_visits[pipeline][0]  # "j8zs05020"
     put_moto_s3_object(dataset, bucketname)
     pred = local_handler(dataset, bucket_name=bucketname)
     for k, v in pred.predictions.items():
@@ -48,7 +48,9 @@ def test_local_handler_multiple(cal_predict_visits, pipeline):
     bucketname = "spacekit_bucket"
     s3 = boto3.resource("s3", region_name="us-east-1")
     s3.create_bucket(Bucket=bucketname)
-    datasets = cal_predict_visits[pipeline]# ["j8zs05020", "ic0k06010", "la8mffg5q", "oc3p011i0"]
+    datasets = cal_predict_visits[
+        pipeline
+    ]  # ["j8zs05020", "ic0k06010", "la8mffg5q", "oc3p011i0"]
     for dataset in datasets:
         put_moto_s3_object(dataset, bucketname)
         pred = local_handler(dataset, bucket_name=bucketname)
@@ -65,7 +67,9 @@ def test_lambda_handler(cal_predict_visits, pipeline):
     bucketname = "spacekit_bucket"
     s3 = boto3.resource("s3", region_name="us-east-1")
     s3.create_bucket(Bucket=bucketname)
-    dataset = cal_predict_visits[pipeline][0] # ["j8zs05020", "ic0k06010", "la8mffg5q", "oc3p011i0"]
+    dataset = cal_predict_visits[pipeline][
+        0
+    ]  # ["j8zs05020", "ic0k06010", "la8mffg5q", "oc3p011i0"]
     put_moto_s3_object(dataset, bucketname)
     os.environ["MODEL_PATH"] = "models/calmodels"
     key = f"control/{dataset}/{dataset}_MemModelFeatures.txt"

--- a/tests/skopes/hst/svm/test_svm_predict.py
+++ b/tests/skopes/hst/svm/test_svm_predict.py
@@ -1,5 +1,6 @@
 import os
 from pytest import mark
+from conftest import check_skope
 from spacekit.builder.architect import BuilderEnsemble
 from spacekit.skopes.hst.svm.predict import (
     predict_alignment,
@@ -7,12 +8,13 @@ from spacekit.skopes.hst.svm.predict import (
     classify_alignments,
 )
 
-
+@mark.hst
 @mark.svm
 @mark.predict
-def test_predict_alignment(svm_unlabeled_dataset, svm_pred_img, tmp_path):
+def test_predict_alignment(skope, unlabeled_dataset, svm_pred_img, tmp_path):
+    check_skope(skope, "svm")
     preds = predict_alignment(
-        svm_unlabeled_dataset, svm_pred_img, output_path=tmp_path, size=128
+        unlabeled_dataset, svm_pred_img, output_path=tmp_path, size=128
     )
     assert len(preds) > 0
     pred_files = os.path.join(tmp_path, "predictions")
@@ -21,15 +23,16 @@ def test_predict_alignment(svm_unlabeled_dataset, svm_pred_img, tmp_path):
     for e in expected:
         assert e in actual
 
-
+@mark.hst
 @mark.svm
 @mark.predict
-def test_load_predict(svm_unlabeled_dataset, svm_pred_img, tmp_path):
+def test_load_predict(skope, unlabeled_dataset, svm_pred_img, tmp_path):
+    check_skope(skope, "svm")
     ens = BuilderEnsemble()
     ens.load_saved_model(arch="ensemble")
     ens.find_tx_file()
     X = load_mixed_inputs(
-        svm_unlabeled_dataset, svm_pred_img, size=128, tx=ens.tx_file, norm=0
+        unlabeled_dataset, svm_pred_img, size=128, tx=ens.tx_file, norm=0
     )
     assert X[0].shape == (2, 10)
     assert X[1].shape == (2, 3, 128, 128, 3)

--- a/tests/skopes/hst/svm/test_svm_predict.py
+++ b/tests/skopes/hst/svm/test_svm_predict.py
@@ -8,6 +8,7 @@ from spacekit.skopes.hst.svm.predict import (
     classify_alignments,
 )
 
+
 @mark.hst
 @mark.svm
 @mark.predict
@@ -22,6 +23,7 @@ def test_predict_alignment(skope, unlabeled_dataset, svm_pred_img, tmp_path):
     actual = os.listdir(pred_files)
     for e in expected:
         assert e in actual
+
 
 @mark.hst
 @mark.svm

--- a/tests/skopes/hst/svm/test_svm_train.py
+++ b/tests/skopes/hst/svm/test_svm_train.py
@@ -1,5 +1,7 @@
 import os
+from conftest import check_skope
 from pytest import mark
+
 from spacekit.skopes.hst.svm.train import load_ensemble_data, run_training
 
 EXPECTED_RES = [
@@ -27,10 +29,12 @@ PARAMS = dict(
 )
 
 
+@mark.hst
 @mark.svm
 @mark.train
 @mark.parametrize("norm", [(1), (0)])
-def test_svm_training(labeled_dataset, svm_train_npz, norm):
+def test_svm_training(skope, labeled_dataset, svm_train_npz, norm):
+    check_skope(skope, "svm")
     output_path = os.path.join("tmp", "2021-11-04-1636048291")
     ens, com, _ = run_training(
         labeled_dataset,
@@ -68,9 +72,11 @@ def test_svm_training(labeled_dataset, svm_train_npz, norm):
     assert [r in res_actual for r in EXPECTED_RES]
 
 
+@mark.hst
 @mark.svm
 @mark.train
-def test_load_training_data(labeled_dataset, svm_train_img):
+def test_load_training_data(skope, labeled_dataset, svm_train_img):
+    check_skope(skope, "svm")
     tv_idx, XTR, YTR, XTS, YTS, XVL, YVL = load_ensemble_data(
         labeled_dataset,
         svm_train_img,

--- a/tests/skopes/hst/svm/test_svm_train.py
+++ b/tests/skopes/hst/svm/test_svm_train.py
@@ -30,10 +30,10 @@ PARAMS = dict(
 @mark.svm
 @mark.train
 @mark.parametrize("norm", [(1), (0)])
-def test_svm_training(svm_labeled_dataset, svm_train_npz, norm):
+def test_svm_training(labeled_dataset, svm_train_npz, norm):
     output_path = os.path.join("tmp", "2021-11-04-1636048291")
     ens, com, _ = run_training(
-        svm_labeled_dataset,
+        labeled_dataset,
         svm_train_npz,
         img_size=128,
         norm=norm,
@@ -70,9 +70,9 @@ def test_svm_training(svm_labeled_dataset, svm_train_npz, norm):
 
 @mark.svm
 @mark.train
-def test_load_training_data(svm_labeled_dataset, svm_train_img):
+def test_load_training_data(labeled_dataset, svm_train_img):
     tv_idx, XTR, YTR, XTS, YTS, XVL, YVL = load_ensemble_data(
-        svm_labeled_dataset,
+        labeled_dataset,
         svm_train_img,
         img_size=128,
         norm=0,


### PR DESCRIPTION
- Model training results files saved as pickle objects using Pandas 1.x could not be loaded with Pandas 2.x. New functionality added to extractor/load.py and used by the Compute module where model training results files are saved as a combination of .npy,.npz,.csv, and .json formats instead of pickle objects. This allows compatibility across Pandas 1.x and 2.x.

- Existing model results for pretrained networks and pytest have been updated and uploaded to Zenodo