### PR TITLE
bugfix/astroquery-import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.0.1 (unreleased)
 ==================
 
+bugfixes
+--------
+
+- try/except imports for astroquery and progressbar no longer global; pin tf max version to ensure saved model compatibility [#48]
+
+
 installation / automation
 -------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@
 bugfixes
 --------
 
-- move HstSvmRadio import inside class method to avoid importing astroquery unnecessarily; temporarily pin tf max version to 2.15 to ensure compatibility with models saved in 2.13 or older [#49]
+- move HstSvmRadio import inside class method to avoid importing astroquery unnecessarily [#49]
+
+- temporarily pin tf max version to 2.15 to ensure compatibility with models saved in 2.13 or older
+
+- matplotlib style setting looks for "seaborn-v0_8-bright" if "seaborn-bright" unavailable, fallback uses default style
 
 
 installation / automation

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 bugfixes
 --------
 
-- try/except imports for astroquery and progressbar no longer global; pin tf max version to ensure saved model compatibility [#48]
+- moved HstSvmRadio import inside class method to avoid importing astroquery unnecessarily; pin tf max version to ensure saved model compatibility [#48]
 
 
 installation / automation

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 bugfixes
 --------
 
-- moved HstSvmRadio import inside class method to avoid importing astroquery unnecessarily; pin tf max version to ensure saved model compatibility [#48]
+- move HstSvmRadio import inside class method to avoid importing astroquery unnecessarily; temporarily pin tf max version to 2.15 to ensure compatibility with models saved in 2.13 or older [#49]
 
 
 installation / automation

--- a/docker/images/dashboard_image/Dockerfile
+++ b/docker/images/dashboard_image/Dockerfile
@@ -5,8 +5,6 @@ RUN apt update && \
     apt upgrade --assume-yes && \
     ACCEPT_EULA=Y DEBIAN_FRONTEND=noninteractive && \
     apt install --assume-yes \
-        # wget \
-        # make \
         sudo \
         git \
         vim \
@@ -42,7 +40,6 @@ RUN python3 -m venv /home/developer/venv && \
     dash~=2.0.0 \
     dash-cytoscape \
     dash-daq && \
-  pip uninstall werkzeug -y && pip install werkzeug==2.0.3 && \
   mkdir /home/developer/data && \
   python -m spacekit.datasets.beam -s="${SRC}:${COLLECTION}" -d=$DATASETS -o=$SPACEKIT_DATA
 

--- a/docs/source/skopes/hst/cal/predict.rst
+++ b/docs/source/skopes/hst/cal/predict.rst
@@ -1,5 +1,5 @@
 *******************************
-spacekit.skopes.hst.svm.predict
+spacekit.skopes.hst.cal.predict
 *******************************
 
 .. currentmodule:: spacekit.skopes.hst.cal.predict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ exclude = [
     'dist',
     '.egg',
 ]
-
+[tool.ruff.lint]
 ignore = [
     'E741', # ambiguous variable name
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
     'spacekit/preprocessor/scrub.py' = ['E712']

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -8,11 +8,9 @@ fi
 
 if [ $MOUNTS -ne 0 ]; then
     docker run ${CONTAINER_MODE} --name $NAME \
-    --ip $IPADDRESS --hostname $HOSTNAME -p 8050:8050 $* \
     --mount type=bind,source=${SOURCEDATA},target=${DESTDATA} \
     $DOCKER_IMAGE $EPCOMMAND
 else
     docker run ${CONTAINER_MODE} --name $NAME \
-    --ip $IPADDRESS --hostname $HOSTNAME -p 8050:8050 $* \
     $DOCKER_IMAGE $EPCOMMAND
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = spacekit
-version = 1.0.0
+version = 1.0.1
 author = Ru Keïn
 author_email = rkein@stsci.edu
 license = MIT
@@ -35,7 +35,7 @@ setup_requires =
     setuptools >=42
 
 install_requires =
-    tensorflow>=2.7
+    tensorflow<2.16
     astropy
     boto3
     numpy>=1.19

--- a/spacekit/analyzer/compute.py
+++ b/spacekit/analyzer/compute.py
@@ -20,10 +20,15 @@ try:
     import plotly.graph_objects as go
     import matplotlib as mpl
     import matplotlib.pyplot as plt
-
-    plt.style.use("seaborn-bright")
     font_dict = {"family": "monospace", "size": 16}  # Titillium Web
     mpl.rc("font", **font_dict)
+    styles = ["seaborn-bright", "seaborn-v0_8-bright"]
+    valid_styles = [s for s in styles if s in plt.style.available]
+    if len(valid_styles) > 0:
+        try:
+            plt.style.use(valid_styles[0])
+        except OSError:
+            pass
 except ImportError:
     go = None
     mpl = None

--- a/spacekit/analyzer/explore.py
+++ b/spacekit/analyzer/explore.py
@@ -15,10 +15,15 @@ except ImportError:
 try:
     import matplotlib as mpl
     import matplotlib.pyplot as plt
-
-    plt.style.use("seaborn-bright")
     font_dict = {"family": "monospace", "size": 16}
     mpl.rc("font", **font_dict)
+    styles = ["seaborn-bright", "seaborn-v0_8-bright"]
+    valid_styles = [s for s in styles if s in plt.style.available]
+    if len(valid_styles) > 0:
+        try:
+            plt.style.use(valid_styles[0])
+        except OSError:
+            pass
 except ImportError:
     mpl = None
     plt = None

--- a/spacekit/extractor/radio.py
+++ b/spacekit/extractor/radio.py
@@ -6,20 +6,21 @@ import numpy as np
 import pandas as pd
 from spacekit.logger.log import Logger
 
+try:
+    from astroquery.mast import Observations
+except ImportError:
+    Observations = None
+
+try:
+    from progressbar import ProgressBar
+except ImportError:
+    ProgressBar = None
 
 def check_astroquery():
-    try:
-        from astroquery.mast import Observations
-    except ImportError:
-        Observations = None
     return Observations is not None
 
 
 def check_progressbar():
-    try:
-        from progressbar import ProgressBar
-    except ImportError:
-        ProgressBar = None
     return ProgressBar is not None
 
 

--- a/spacekit/extractor/radio.py
+++ b/spacekit/extractor/radio.py
@@ -6,28 +6,27 @@ import numpy as np
 import pandas as pd
 from spacekit.logger.log import Logger
 
-try:
-    from astroquery.mast import Observations
-except ImportError:
-    Observations = None
-try:
-    from progressbar import ProgressBar
-except ImportError:
-    ProgressBar = None
-
 
 def check_astroquery():
+    try:
+        from astroquery.mast import Observations
+    except ImportError:
+        Observations = None
     return Observations is not None
 
 
 def check_progressbar():
+    try:
+        from progressbar import ProgressBar
+    except ImportError:
+        ProgressBar = None
     return ProgressBar is not None
 
 
 def check_imports():
-    if not check_astroquery():
+    if not check_progressbar():
         return False
-    elif not check_progressbar():
+    elif not check_astroquery():
         return False
     else:
         return True

--- a/spacekit/preprocessor/scrub.py
+++ b/spacekit/preprocessor/scrub.py
@@ -9,7 +9,6 @@ from spacekit.extractor.scrape import (
     JwstFitsScraper,
     scrape_catalogs,
 )
-from spacekit.extractor.radio import HstSvmRadio
 from spacekit.preprocessor.encode import HstSvmEncoder, JwstEncoder, encode_booleans
 from spacekit.logger.log import Logger
 
@@ -190,6 +189,11 @@ class HstSvmScrubber(Scrubber):
         self.make_subsamples = make_subsamples
         self.set_new_cols()
         self.set_prefix_cols()
+        self.initialize_radio()
+
+    def initialize_radio(self):
+        from spacekit.extractor.radio import HstSvmRadio
+        self.radio = HstSvmRadio
 
     def preprocess_data(self):
         """Main calling function to run each preprocessing step for SVM regression data."""
@@ -200,7 +204,7 @@ class HstSvmScrubber(Scrubber):
         n_retries = 3
         while n_retries > 0:
             try:
-                self.df = HstSvmRadio(self.df).scrape_mast()
+                self.df = self.radio(self.df).scrape_mast()
                 n_retries = 0
             except Exception as e:
                 self.log.warning(e)
@@ -262,7 +266,7 @@ class HstSvmScrubber(Scrubber):
         self.scrub_columns()
         # STAGE 2 initial encoding
         self.df = SvmFitsScraper(self.df, self.input_path).scrape_fits()
-        self.df = HstSvmRadio(self.df).scrape_mast()
+        self.df = self.radio(self.df).scrape_mast()
 
     def scrub_qa_summary(self, csvfile="single_visit_mosaics*.csv", idx=0):
         """Alternative if no .json files available (QA step not run during processing)"""

--- a/tests/skopes/hst/cal/test_hst_cal_predict.py
+++ b/tests/skopes/hst/cal/test_hst_cal_predict.py
@@ -1,6 +1,6 @@
 import os
 from pytest import mark
-from moto import mock_s3
+from moto import mock_aws
 from spacekit.skopes.hst.cal.predict import local_handler, lambda_handler
 import boto3
 
@@ -27,7 +27,7 @@ def put_moto_s3_object(dataset, bucketname):
 @mark.cal
 @mark.predict
 @mark.parametrize("pipeline", [("asn")])
-@mock_s3
+@mock_aws
 def test_local_predict_handler(hst_cal_predict_visits, pipeline):
     bucketname = "spacekit_bucket"
     s3 = boto3.resource("s3", region_name="us-east-1")
@@ -43,7 +43,7 @@ def test_local_predict_handler(hst_cal_predict_visits, pipeline):
 @mark.cal
 @mark.predict
 @mark.parametrize("pipeline", [("asn")])
-@mock_s3
+@mock_aws
 def test_local_handler_multiple(hst_cal_predict_visits, pipeline):
     bucketname = "spacekit_bucket"
     s3 = boto3.resource("s3", region_name="us-east-1")
@@ -62,7 +62,7 @@ def test_local_handler_multiple(hst_cal_predict_visits, pipeline):
 @mark.cal
 @mark.predict
 @mark.parametrize("pipeline", [("asn")])
-@mock_s3
+@mock_aws
 def test_lambda_handler(hst_cal_predict_visits, pipeline):
     bucketname = "spacekit_bucket"
     s3 = boto3.resource("s3", region_name="us-east-1")

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ skip_install = true
 changedir = .
 description = check code style with ruff
 deps = ruff
-commands = ruff . {posargs}
+commands = ruff check . {posargs}
 
 [testenv:check-security]
 skip_install = true


### PR DESCRIPTION
Resolves JP-3591

- move HstSvmRadio import inside class method to avoid importing astroquery for other Scrub module sub-classes
- temporarily pin tensorflow max version to 2.15 to ensure compatibility with models saved in tf 2.13 or older

Test config updates: 
- replace mock_s3 with mock_aws
- matplotlib style settings (seaborn-bright replacement)
- ruff.lint replaces depreacted top-level linter