### PR TITLE
deps/numpy-2-compat

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.1.2 (unreleased)
+==================
+
+preprocessor
+------------
+- explicitly pass `encoding=bytes` in transform.hypersonic_pliers for numpy 2 compatibility where this will no longer be the default for np.loadtxt [#92]
+
+
 1.1.1 (2024-07-11)
 ==================
 

--- a/spacekit/analyzer/explore.py
+++ b/spacekit/analyzer/explore.py
@@ -980,7 +980,7 @@ class SignalPlots:
             x_units = x_units
 
         # Scatter Plot
-        if type(signal) == np.array:
+        if isinstance(signal, np.array):
             series_index = list(range(len(signal)))
 
             converted_array = pd.Series(signal.ravel(), index=series_index)

--- a/spacekit/extractor/load.py
+++ b/spacekit/extractor/load.py
@@ -377,7 +377,7 @@ class ImageIO:
         arrays
             split sampled arrays
         """
-        if type(data) == pd.DataFrame:
+        if isinstance(data, pd.DataFrame):
             sample = data.sample(frac=1)
         else:
             sample = data

--- a/spacekit/extractor/scrape.py
+++ b/spacekit/extractor/scrape.py
@@ -9,6 +9,7 @@ import json
 import csv
 from zipfile import ZipFile
 from astropy.io import fits, ascii
+from astropy.table import Table
 from botocore.config import Config
 from decimal import Decimal
 from boto3.dynamodb.conditions import Attr
@@ -1428,10 +1429,7 @@ class JsonScraper(FileScraper):
                 ingest_key = fd_key.replace(" ", "_")
                 key_suffix = ingest_key.split(".")[-1]
                 if key_suffix not in ["data", "unit", "format", "dtype"]:
-                    if (
-                        str(type(json_data_item))
-                        == "<class 'astropy.table.table.Table'>"
-                    ):
+                    if isinstance(json_data_item, Table):
                         for coltitle in json_data_item.colnames:
                             ingest_value = json_data_item[coltitle].tolist()
                             id_key = title_suffix + ingest_key + "." + coltitle
@@ -1439,7 +1437,7 @@ class JsonScraper(FileScraper):
                     else:
                         ingest_value = json_data_item
                         id_key = title_suffix + ingest_key
-                        if str(type(ingest_value)) == "<class 'list'>":
+                        if isinstance(ingest_value, list):
                             ingest_dict["data"][id_key] = [ingest_value]
                         else:
                             ingest_dict["data"][id_key] = ingest_value

--- a/spacekit/preprocessor/transform.py
+++ b/spacekit/preprocessor/transform.py
@@ -775,7 +775,7 @@ def normalize_training_images(X_tr, X_ts, X_vl=None):
 
 
 def array_to_tensor(arr, reshape=False, shape=(-1, 1)):
-    if type(arr) == tf.Tensor:
+    if isinstance(arr, tf.Tensor):
         return arr
     if reshape is True:
         arr = arr.reshape(shape[0], shape[1])

--- a/spacekit/preprocessor/transform.py
+++ b/spacekit/preprocessor/transform.py
@@ -869,7 +869,7 @@ def tensors_to_arrays(X_train, y_train, X_test, y_test):
 
 
 def hypersonic_pliers(
-    path_to_train, path_to_test, y_col=[0], skip=1, dlm=",", subtract_y=0.0
+    path_to_train, path_to_test, y_col=[0], skip=1, dlm=",", encoding=bytes, subtract_y=0.0
 ):
     """Extracts data into 1-dimensional arrays, using separate target classes (y) for training and test data. Assumes y (target)
     is first column in dataframe. If the target (y) classes in the raw data are 0 and 2, but you'd like them to be binaries (0
@@ -887,6 +887,8 @@ def hypersonic_pliers(
         skiprows parameter for np.loadtxt, by default 1
     dlm : str, optional
         delimiter, by default ","
+    encoding: str, optional
+        explicitly passed encoding type to numpy.loadtxt, by default bytes
     subtract_y : float, optional
         subtract this value from all y-values, by default 1.0
 
@@ -895,7 +897,7 @@ def hypersonic_pliers(
     np.ndarrays
         X_train, X_test, y_train, y_test
     """
-    Train = np.loadtxt(path_to_train, skiprows=skip, delimiter=dlm)
+    Train = np.loadtxt(path_to_train, skiprows=skip, delimiter=dlm, encoding=encoding)
     cols = list(range(Train.shape[1]))
     xcols = [c for c in cols if c not in y_col]
     # X_train = Train[:, 1:]
@@ -903,7 +905,7 @@ def hypersonic_pliers(
     # y_train = Train[:, 0, np.newaxis] - subtract_y
     y_train = Train[:, y_col, np.newaxis] - subtract_y
 
-    Test = np.loadtxt(path_to_test, skiprows=skip, delimiter=dlm)
+    Test = np.loadtxt(path_to_test, skiprows=skip, delimiter=dlm, encoding=encoding)
     X_test = Test[:, xcols]
     y_test = Test[:, y_col, np.newaxis] - subtract_y
     # X_test = Test[:, 1:]


### PR DESCRIPTION
- Adds optional arg `encoding=bytes` in preprocessor.transform.hypersonic_pliers which uses np.loadtxt. This ensures consistent behavior for future upgrades to Numpy>=2.0 where the default will be changed to `str`.
- Minor formatting fixes: use `isinstance()` for type checking 